### PR TITLE
Update flourish to include more on the reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ interface Tweet extends Node {
 interface FlourishReference extends Reference {
 	referencedType: "flourish"
 	flourishType: string
+	layoutWidth: "" | "full-grid"
+	description: string
+	timestamp: string
 }
 ```
 
@@ -369,6 +372,7 @@ interface Flourish extends Node {
 	layoutWidth: "" | "full-grid"
 	flourishType: string
 	description: string
+	timestamp: string
 	fallbackImage: Image
 }
 ```

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -116,6 +116,9 @@ export declare namespace ContentTree {
     interface FlourishReference extends Reference {
         referencedType: "flourish";
         flourishType: string;
+        layoutWidth: "" | "full-grid";
+        description: string;
+        timestamp: string;
     }
     interface Flourish extends Node {
         type: "flourish";
@@ -123,6 +126,7 @@ export declare namespace ContentTree {
         layoutWidth: "" | "full-grid";
         flourishType: string;
         description: string;
+        timestamp: string;
         fallbackImage: Image;
     }
     interface BigNumber extends Parent {


### PR DESCRIPTION
These are all properties that are available on the <ft-content> tag at the moment: `<ft-content type=\"http://www.ft.com/ontology/content/Content\" url=\"http://api.ft.com/content/1760409\" alt=\"\" data-asset-type=\"flourish\" data-embedded=\"true\" data-flourish-type=\"story\" data-layout-width=\"\" data-time-stamp=\"\" id=\"1760409\"></ft-content>`