### PR TITLE
External nodes should have id and optional external fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ interface ImageSource {
 
 ```ts
 interface External {
+	id: string
 	external: string[]
 }
 ```
@@ -365,15 +366,11 @@ was more engaging, and Spark (and therefore content-tree)now only supports that 
 ### `ImageSet`
 
 ```ts
-interface ImageSetContent {
-
-}
-
 interface ImageSet extends Node, External {
 	type: "image-set"
 	layoutWidth: "inline" | "article" | "grid" | "viewport"
 	external: ["picture"]
-	picture: {
+	picture?: {
 		imageType: "image" | "graphic"
 		alt: string
 		caption: string
@@ -410,7 +407,7 @@ interface Image extends Node {
 interface Tweet extends Node, External {
 	type: "tweet"
 	external: ["html"]
-	html: string
+	html?: string
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -7,6 +7,7 @@ export declare namespace ContentTree {
         dpr: number;
     }
     interface External {
+        id: string;
         external: string[];
     }
     interface TeaserConcept {
@@ -125,13 +126,11 @@ export declare namespace ContentTree {
         external: ["teaser"];
         teaser?: Teaser;
     }
-    interface ImageSetContent {
-    }
     interface ImageSet extends Node, External {
         type: "image-set";
         layoutWidth: "inline" | "article" | "grid" | "viewport";
         external: ["picture"];
-        picture: {
+        picture?: {
             imageType: "image" | "graphic";
             alt: string;
             caption: string;
@@ -152,7 +151,7 @@ export declare namespace ContentTree {
     interface Tweet extends Node, External {
         type: "tweet";
         external: ["html"];
-        html: string;
+        html?: string;
     }
     interface Flourish extends Node, External {
         type: "flourish";


### PR DESCRIPTION
We need an `id` to be able to look up external references.

The external propert(ies) should be optional, as they won't be there when creating the node.