### PR TITLE
remove the concept of externals entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link
 Phrasing nodes cannot have an ancestor of their same type.
 TODO: clarify that i mean Strong cannot have an ancestor of Strong etc
 
-### `SourceSet`
+### `ImageSource`
 
 ```ts
 interface ImageSource {
@@ -61,16 +61,7 @@ interface ImageSource {
 }
 ```
 
-### `External`
-
-```ts
-interface External {
-	id: string
-	external: string[]
-}
-```
-
-**External** represents a reference to a piece of external content.
+**ImageSource** are the shapes of things in an [image](#image)'s sourceSet
 
 ### `Teaser`
 
@@ -143,7 +134,8 @@ interface Node {
 }
 ```
 
-The abstract node.
+The abstract node. The data field is for internal implementation information and
+will never be defined in the content-tree spec.
 
 ### `Parent`
 
@@ -342,12 +334,12 @@ doesn't. The text is taken from elsewhere in the article.
 ### `Recommended`
 
 ```ts
-interface Recommended extends Node, External {
+interface Recommended extends Node {
 	type: "recommended"
+	id: string
 	heading?: string
 	teaserTitleOverride?: string
-	external: ["teaser"]
-	teaser?: Teaser
+	teaser: Teaser
 }
 ```
 
@@ -366,11 +358,11 @@ was more engaging, and Spark (and therefore content-tree)now only supports that 
 ### `ImageSet`
 
 ```ts
-interface ImageSet extends Node, External {
+interface ImageSet extends Node {
 	type: "image-set"
+	id: string
 	layoutWidth: "inline" | "article" | "grid" | "viewport"
-	external: ["picture"]
-	picture?: {
+	picture: {
 		imageType: "image" | "graphic"
 		alt: string
 		caption: string
@@ -404,10 +396,9 @@ interface Image extends Node {
 ### `Tweet`
 
 ```ts
-interface Tweet extends Node, External {
+interface Tweet extends Node {
+	id: string
 	type: "tweet"
-	external: ["html"]
-	html?: string
 }
 ```
 
@@ -416,14 +407,14 @@ interface Tweet extends Node, External {
 ### `Flourish`
 
 ```ts
-interface Flourish extends Node, External {
+interface Flourish extends Node {
 	type: "flourish"
+	id: string
 	layoutWidth: "article" | "grid"
 	flourishType: string
 	description?: string
 	timestamp?: string
-	external: ["fallbackImage"]
-	fallbackImage?: Image
+	fallbackImage: Image
 }
 ```
 
@@ -568,13 +559,13 @@ _Non-normative note_: typically these would be displayed as flex items, so they 
 
 ```ts
 
-interface LayoutImage extends External, Node {
+interface LayoutImage extends Node {
 	type: "layout-image"
+	id: string
 	alt: string
 	caption: string
 	credit: string
-	external: ["picture"]
-	picture?: Image
+	picture: Image
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -6,10 +6,6 @@ export declare namespace ContentTree {
         width: number;
         dpr: number;
     }
-    interface External {
-        id: string;
-        external: string[];
-    }
     interface TeaserConcept {
         apiUrl: string;
         directType: string;
@@ -119,18 +115,18 @@ export declare namespace ContentTree {
         text: string;
         source?: string;
     }
-    interface Recommended extends Node, External {
+    interface Recommended extends Node {
         type: "recommended";
+        id: string;
         heading?: string;
         teaserTitleOverride?: string;
-        external: ["teaser"];
-        teaser?: Teaser;
+        teaser: Teaser;
     }
-    interface ImageSet extends Node, External {
+    interface ImageSet extends Node {
         type: "image-set";
+        id: string;
         layoutWidth: "inline" | "article" | "grid" | "viewport";
-        external: ["picture"];
-        picture?: {
+        picture: {
             imageType: "image" | "graphic";
             alt: string;
             caption: string;
@@ -148,19 +144,18 @@ export declare namespace ContentTree {
         binaryUrl: string;
         sourceSet: ImageSource[];
     }
-    interface Tweet extends Node, External {
+    interface Tweet extends Node {
+        id: string;
         type: "tweet";
-        external: ["html"];
-        html?: string;
     }
-    interface Flourish extends Node, External {
+    interface Flourish extends Node {
         type: "flourish";
+        id: string;
         layoutWidth: "article" | "grid";
         flourishType: string;
         description?: string;
         timestamp?: string;
-        external: ["fallbackImage"];
-        fallbackImage?: Image;
+        fallbackImage: Image;
     }
     interface BigNumber extends Parent {
         type: "big-number";
@@ -214,13 +209,13 @@ export declare namespace ContentTree {
         type: "layout-slot";
         children: (Heading | Paragraph | LayoutImage)[];
     }
-    interface LayoutImage extends External, Node {
+    interface LayoutImage extends Node {
         type: "layout-image";
+        id: string;
         alt: string;
         caption: string;
         credit: string;
-        external: ["picture"];
-        picture?: Image;
+        picture: Image;
     }
     interface Table extends Parent {
         type: "table";


### PR DESCRIPTION
we were making a lot of concessions for the current implementations of things inside the content-tree spec, but with the looming reality that content-tree may well outlive both Spark and cp-content-pipeline we realized the information as to what is external and what is not is no actually the content-tree's business and is an implementation detail

questions:

- should we use `url` instead of `id` for tweet?
- what about the recommended, should it use `teaserId`?
- and flourish... should it have a separate `id`/url and `fallbackImageId`? not sure