### PR TITLE
Updates BigNumber interface to extend Node instead of Parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ interface Flourish extends Node {
 ### `BigNumber`
 
 ```ts
-interface BigNumber extends Parent {
+interface BigNumber extends Node {
 	type: "big-number"
 	number: string
 	description: string

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -158,7 +158,7 @@ export declare namespace ContentTree {
         timestamp?: string;
         fallbackImage?: Image;
     }
-    interface BigNumber extends Parent {
+    interface BigNumber extends Node {
         type: "big-number";
         number: string;
         description: string;


### PR DESCRIPTION
Previous changes mean that BigNumber no longer needs to extend Parent as it no longer has Children.