### PR TITLE
Add the ftedit square image as a valid format

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ type Image = {
 		| "desktop"
 		| "mobile"
 		| "square"
+		| "square-ftedit"
 		| "standard"
 		| "wide"
 		| "standard-inline"

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -52,7 +52,7 @@ export declare namespace ContentTree {
         id: string;
         width: number;
         height: number;
-        format: "desktop" | "mobile" | "square" | "standard" | "wide" | "standard-inline";
+        format: "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline";
         url: string;
         sourceSet?: ImageSource[];
     };


### PR DESCRIPTION
This format field needs some work, but we can get around to that later and update Content-Tree when we have had time to rethink images.

This is the image format value currently called `ftEditSquare`.