### PR TITLE
add tables to the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,22 +554,33 @@ interface LayoutImage extends Node {
 
 - **LayoutImage** is a workaround to handle pre-existing articles that were published using `<img>` tags rather than `<ft-content>` images. The reason for this was that in the bodyXML, layout nodes were inside an `<experimental>` tag, and that didn't support publishing `<ft-content>`.
 
-### TODO: `Table`
+### `Table`
 
 ```ts
-interface Table extends Parent {
-	type: "table"
-	children: [Caption | TableHead | TableBody]
+type TableColumnSettings = {
+	hideOnMobile: boolean
+	sortable: boolean
+	sortType: "text" | "number" | "date" | "currency" | "percent"
 }
 
-interface Caption {
-	type: "caption"
+interface Table extends Parent {
+	type: "table"
+	title: string
+	footer: string
+	stripes: boolean
+	compact: boolean
+	layoutWidth: string
+	rows: number
+	columns: number
+	collapseAfterHowManyRows: number
+	responsiveStyle: "stacked" | "scroll"
+	children: TableCell[]
+	columnSettings: TableColumnSettings[]
 }
-interface TableHead {
-	type: "table-head"
-}
-interface TableBody {
-	type: "table-body"
+
+interface TableCell {
+	type: "table-cell"
+	children: Phrasing[]
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -211,17 +211,27 @@ export declare namespace ContentTree {
         credit: string;
         picture?: ImageSetPicture;
     }
+    type TableColumnSettings = {
+        hideOnMobile: boolean;
+        sortable: boolean;
+        sortType: "text" | "number" | "date" | "currency" | "percent";
+    };
     interface Table extends Parent {
         type: "table";
-        children: [Caption | TableHead | TableBody];
+        title: string;
+        footer: string;
+        stripes: boolean;
+        compact: boolean;
+        layoutWidth: string;
+        rows: number;
+        columns: number;
+        collapseAfterHowManyRows: number;
+        responsiveStyle: "stacked" | "scroll";
+        children: TableCell[];
+        columnSettings: TableColumnSettings[];
     }
-    interface Caption {
-        type: "caption";
-    }
-    interface TableHead {
-        type: "table-head";
-    }
-    interface TableBody {
-        type: "table-body";
+    interface TableCell {
+        type: "table-cell";
+        children: Phrasing[];
     }
 }


### PR DESCRIPTION
something got messed up with #12 via a force push. i'm not sure what happened. recreating the PR.

---

The property names could use some work.
There is no concept of header rows, or rows at all. The belief is that with the `rows` and `columns` properties you should be able to work all that out yourself. the header row is always the first $rows number of cells.

in spark there is always 1 header row, and the rows can never have variable numbers of clls.