### PR TITLE
Scrollytelling definition updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,8 +506,7 @@ interface ScrollyHeading extends Parent {
 }
 ```
 
-**ScrollyText** represents an individual unit of copy for a
-[ScrollyBlock](#scrollableblock)
+**ScrollyHeading** represents a heading within a **ScrollyCopy** block.
 
 ### `Layout`
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,8 @@ interface ScrollyBlock extends Parent {
 ```ts
 interface ScrollySection extends Parent {
 	type: "scrolly-section"
-	theme: "dark-text" | "light-text" | "dark-text-no-box" | "light-text-no-box"
+	display: "dark-background" | "light-background"
+	noBox?: true,
 	position: "left" | "center" | "right"
 	transition?: "delay-before" | "delay-after"
 	children: [ImageSet, ...ScrollyCopy[]]

--- a/README.md
+++ b/README.md
@@ -478,30 +478,19 @@ interface ScrollySection extends Parent {
 ```ts
 interface ScrollyCopy extends Parent {
 	type: "scrolly-copy"
-	children: ScrollyText[]
+	children: (ScrollyHeading | Paragraph)[]
 }
 ```
 
 TODO is this badly named?
 
-**ScrollyCopy** represents a collection of **ScrollyText** nodes.
+**ScrollyCopy** represents a collection of **ScrollyHeading** or **Paragraph** nodes.
 
 ```ts
-interface ScrollyText extends Parent {
-	type: "scrolly-text"
-	level: string
-}
-
-interface ScrollyHeading extends ScrollyText {
+interface ScrollyHeading extends Parent {
 	type: "scrolly-text"
 	level: "chapter" | "heading" | "subheading"
 	children: Text[]
-}
-
-interface ScrollyParagraph extends ScrollyText {
-	type: "scrolly-text"
-	level: "text"
-	children: Phrasing[]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -466,13 +466,24 @@ interface ScrollySection extends Parent {
 	noBox?: true,
 	position: "left" | "center" | "right"
 	transition?: "delay-before" | "delay-after"
-	children: [ImageSet, ...ScrollyCopy[]]
+	children: [ScrollyImage, ...ScrollyCopy[]]
 }
 ```
 
 **ScrollySection** represents a section of a [ScrollyBlock](#scrollyblock)
 
 - TODO: could `transition` have a `"none"` value so it isn't optional?
+
+### `ScrollyImage`
+
+```ts
+interface ScrollyImage extends Node {
+	type: "scrolly-image"
+	id: string
+}
+```
+
+**ScrollyImage** represents an image contained in a [ScrollySection](#scrollysection)
 
 ### `ScrollyCopy`
 

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ TODO is this badly named?
 
 ```ts
 interface ScrollyHeading extends Parent {
-	type: "scrolly-text"
+	type: "scrolly-heading"
 	level: "chapter" | "heading" | "subheading"
 	children: Text[]
 }

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -180,7 +180,7 @@ export declare namespace ContentTree {
         children: (ScrollyHeading | Paragraph)[];
     }
     interface ScrollyHeading extends Parent {
-        type: "scrolly-text";
+        type: "scrolly-heading";
         level: "chapter" | "heading" | "subheading";
         children: Text[];
     }

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -174,7 +174,11 @@ export declare namespace ContentTree {
         noBox?: true;
         position: "left" | "center" | "right";
         transition?: "delay-before" | "delay-after";
-        children: [ImageSet, ...ScrollyCopy[]];
+        children: [ScrollyImage, ...ScrollyCopy[]];
+    }
+    interface ScrollyImage extends Node {
+        type: "scrolly-image";
+        id: string;
     }
     interface ScrollyCopy extends Parent {
         type: "scrolly-copy";

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -170,7 +170,8 @@ export declare namespace ContentTree {
     }
     interface ScrollySection extends Parent {
         type: "scrolly-section";
-        theme: "dark-text" | "light-text" | "dark-text-no-box" | "light-text-no-box";
+        display: "dark-background" | "light-background";
+        noBox?: true;
         position: "left" | "center" | "right";
         transition?: "delay-before" | "delay-after";
         children: [ImageSet, ...ScrollyCopy[]];

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -177,21 +177,12 @@ export declare namespace ContentTree {
     }
     interface ScrollyCopy extends Parent {
         type: "scrolly-copy";
-        children: ScrollyText[];
+        children: (ScrollyHeading | Paragraph)[];
     }
-    interface ScrollyText extends Parent {
-        type: "scrolly-text";
-        level: string;
-    }
-    interface ScrollyHeading extends ScrollyText {
+    interface ScrollyHeading extends Parent {
         type: "scrolly-text";
         level: "chapter" | "heading" | "subheading";
         children: Text[];
-    }
-    interface ScrollyParagraph extends ScrollyText {
-        type: "scrolly-text";
-        level: "text";
-        children: Phrasing[];
     }
     interface Layout extends Parent {
         type: "layout";


### PR DESCRIPTION
- simplifies ScrollyCopy children to use ScrollyHeading and vanilla Paragraph
- closer align ScrollySection options to Spark/n-scrollytelling
- use a separate ScrollyImage node to represent images in ScrollySections