### PR TITLE
Add an initial clip-set definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,52 @@ interface BigNumber extends Node {
 
 **BigNumber** represents a big number.
 
+### `Clip`
+
+#### `ClipSet`
+
+```ts
+interface ClipSet extends Node {
+  type: "clip-set"
+  id: string
+  autoplay: boolean
+  loop: boolean
+  muted: boolean
+  dataLayout: string
+  external noAudio: boolean
+  external caption: string
+  external credits: string
+  external description: string
+  external displayTitle: string
+  external subtitle: string
+  external clips: Clip[]
+}
+```
+
+```ts
+type Clip {
+  id: string
+  format: string
+  dataSource: ClipSource[]
+  poster: string
+}
+```
+
+```ts
+type ClipSource {
+  audioCodec: string
+  binaryUrl: string
+  duration: number
+  mediaType: string
+  pixelHeight: number
+  pixelWidth: number
+  videoCodec: string
+}
+```
+
+**ClipSet** represents a short piece of possibly-looping video content for an article.
+
+
 ### `Video`
 
 ```ts
@@ -527,7 +573,6 @@ interface Video extends Node {
 
 **Video** represents for an FT video referenced by a URL.
 
-TODO: Figure out how Clips work, how they are different?
 
 ### `YoutubeVideo`
 


### PR DESCRIPTION
This should be right for how they work right now, but I'm going to suggest we don't merge this.

Currently `"clip-set"` is very different from the other things in content-tree (property names and data structure) so i think it would behoove us to get it more in line before we make this final, that'll involve some work with customer products in their cp-content-pipeline repo. But i've been informed that they'd be well up for it.