### PR TITLE
Replace digital-newsroom with spark-team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Financial-Times/content-team @Financial-Times/digital-newsroom @Financial-Times/r13n
+* @Financial-Times/content-team @Financial-Times/spark-team @Financial-Times/r13n @chee


### PR DESCRIPTION
this isn't owned by the whole of edtech