### PR TITLE
map `ft-content` bodyxml nodes to content-tree nodes

### DIFF
--- a/libraries/from-bodyxml/index.js
+++ b/libraries/from-bodyxml/index.js
@@ -272,7 +272,7 @@ export function fromXast(bodyxast, transformers = defaultTransformers) {
 				return xmlnode.children.map(walk)
 			}
 			let transformer =
-				xmlnode.name == "content"
+				(xmlnode.name == "content" || xmlnode.name == "ft-content")
 					? String(xmlnode.attributes.type)
 					: xmlnode.name
 


### PR DESCRIPTION
previously we were only mapping `<content/>` nodes. which, arjun explains, is only what they are called before publishing. in the live `bodyXML` they are called `<ft-content/>`