### PR TITLE
Hyphen missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ type LayoutWidth =
 	| "full-bleed"
 	| "full-grid"
 	| "mid-grid"
+	| "full-width"
 ```
 
 `LayoutWidth` defines how the component should be presented in the article page according to the column layout system.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ type BodyBlock =
 ```ts
 type LayoutWidth =
 	| "auto"
-	| "inline"
+	| "in-line"
 	| "inset-left"
 	| "inset-right"
 	| "full-bleed"

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -1,6 +1,6 @@
 export declare namespace ContentTree {
     type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
-    type LayoutWidth = "auto" | "inline" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid";
+    type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
     type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
     interface Node {
         type: string;
@@ -272,7 +272,7 @@ export declare namespace ContentTree {
     }
     namespace full {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
-        type LayoutWidth = "auto" | "inline" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid";
+        type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
             type: string;
@@ -545,7 +545,7 @@ export declare namespace ContentTree {
     }
     namespace transit {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
-        type LayoutWidth = "auto" | "inline" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid";
+        type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
             type: string;
@@ -813,7 +813,7 @@ export declare namespace ContentTree {
     }
     namespace loose {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
-        type LayoutWidth = "auto" | "inline" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid";
+        type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
             type: string;

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -337,7 +337,8 @@
                 "auto",
                 "full-bleed",
                 "full-grid",
-                "inline",
+                "full-width",
+                "in-line",
                 "inset-left",
                 "inset-right",
                 "mid-grid"

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -594,7 +594,8 @@
                 "auto",
                 "full-bleed",
                 "full-grid",
-                "inline",
+                "full-width",
+                "in-line",
                 "inset-left",
                 "inset-right",
                 "mid-grid"

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -356,7 +356,8 @@
                 "auto",
                 "full-bleed",
                 "full-grid",
-                "inline",
+                "full-width",
+                "in-line",
                 "inset-left",
                 "inset-right",
                 "mid-grid"


### PR DESCRIPTION
Realise inline should be in-line. 

Also added the full-width property as i saw this occur in this PR here (not going to be used for custom component but if we expand the use of that property in the future) - https://github.com/Financial-Times/cp-content-pipeline/pull/823/files#diff-577aeb5fd15aff7121f1c5637223199ad59f2312df9d9dffc6e70236b8d09e60R15 