### PR TITLE
ci-2151 update custom code component

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,8 +730,11 @@ type Attributes = {
 }
 
 interface CustomCodeComponent extends Node {
+  /** Component type */
   type: "custom-code-component"
+  /** Id taken from the CAPI url */
   id: string
+  /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
   embedded: boolean
   /** How the component should be presented in the article page according to the column layout system */
   layoutWidth: LayoutWidth
@@ -739,7 +742,7 @@ interface CustomCodeComponent extends Node {
   external path: string
   /** Semantic version of the code of the component, e.g. "^0.3.5". */
   external versionRange: string
-  /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
+  /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
   external attributesLastModified: string
   /** Configuration data to be passed to the component. */
   external attributes: Attributes

--- a/README.md
+++ b/README.md
@@ -720,23 +720,30 @@ interface Table extends Parent {
 ### CustomCodeComponent
 
 ```ts
-interface CustomCodeComponent extends Parent {
+interface CccFallbackText extends Node {
+    type: 'ccc-fallback-text'
+    children: Paragraph[]
+}
+
+type CccAttributes = {
+    [key: string]: string | boolean | undefined
+}
+
+interface CustomCodeComponent extends Node {
   type: "custom-code-component"
-  /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
-  path: string
-  /** Semantic version of the code of the component, e.g. "^0.3.5". */
-  versionRange: string
-  /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
-  attributesLastModified: string
-  /** A unique identifier for this instance */
   id: string
+  embedded: boolean
   /** How the component should be presented in the article page according to the column layout system */
   layoutWidth: LayoutWidth
+  /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
+  external path: string
+  /** Semantic version of the code of the component, e.g. "^0.3.5". */
+  external versionRange: string
+  /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
+  external attributesLastModified: string
   /** Configuration data to be passed to the component. */
-  attributes: {
-    [key: string]: string | boolean | undefined
-  }
-  children: (ImageSet | Paragraph | CustomCodeComponent)[]
+  external attributes: CccAttributes
+  external children: (ImageSet | CccFallbackText)[]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -720,8 +720,8 @@ interface Table extends Parent {
 ### CustomCodeComponent
 
 ```ts
-interface FallbackText extends Node {
-    type: 'fallback-text'
+interface CccFallbackText extends Node {
+    type: 'ccc-fallback-text'
     children: Paragraph[]
 }
 
@@ -746,7 +746,7 @@ interface CustomCodeComponent extends Node {
   external attributesLastModified: string
   /** Configuration data to be passed to the component. */
   external attributes: Attributes
-  external children: (ImageSet | FallbackText)[]
+  external children: (ImageSet | CccFallbackText)[]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ interface Table extends Parent {
 ### CustomCodeComponent
 
 ```ts
-type Attributes = {
+type CustomCodeComponentAttributes = {
     [key: string]: string | boolean | undefined
 }
 
@@ -738,7 +738,7 @@ interface CustomCodeComponent extends Node {
   /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
   external attributesLastModified: string
   /** Configuration data to be passed to the component. */
-  external attributes: Attributes
+  external attributes: CustomCodeComponentAttributes
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -720,11 +720,6 @@ interface Table extends Parent {
 ### CustomCodeComponent
 
 ```ts
-interface CccFallbackText extends Node {
-    type: 'ccc-fallback-text'
-    children: Paragraph[]
-}
-
 type Attributes = {
     [key: string]: string | boolean | undefined
 }
@@ -746,7 +741,6 @@ interface CustomCodeComponent extends Node {
   external attributesLastModified: string
   /** Configuration data to be passed to the component. */
   external attributes: Attributes
-  external children: (ImageSet | CccFallbackText)[]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -729,8 +729,6 @@ interface CustomCodeComponent extends Node {
   type: "custom-code-component"
   /** Id taken from the CAPI url */
   id: string
-  /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
-  embedded: boolean
   /** How the component should be presented in the article page according to the column layout system */
   layoutWidth: LayoutWidth
   /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */

--- a/README.md
+++ b/README.md
@@ -720,12 +720,12 @@ interface Table extends Parent {
 ### CustomCodeComponent
 
 ```ts
-interface CccFallbackText extends Node {
-    type: 'ccc-fallback-text'
+interface FallbackText extends Node {
+    type: 'fallback-text'
     children: Paragraph[]
 }
 
-type CccAttributes = {
+type Attributes = {
     [key: string]: string | boolean | undefined
 }
 
@@ -742,8 +742,8 @@ interface CustomCodeComponent extends Node {
   /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
   external attributesLastModified: string
   /** Configuration data to be passed to the component. */
-  external attributes: CccAttributes
-  external children: (ImageSet | CccFallbackText)[]
+  external attributes: Attributes
+  external children: (ImageSet | FallbackText)[]
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -260,8 +260,6 @@ export declare namespace ContentTree {
         type: "custom-code-component";
         /** Id taken from the CAPI url */
         id: string;
-        /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
-        embedded: boolean;
         /** How the component should be presented in the article page according to the column layout system */
         layoutWidth: LayoutWidth;
         /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
@@ -535,8 +533,6 @@ export declare namespace ContentTree {
             type: "custom-code-component";
             /** Id taken from the CAPI url */
             id: string;
-            /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
-            embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
             /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
@@ -806,8 +802,6 @@ export declare namespace ContentTree {
             type: "custom-code-component";
             /** Id taken from the CAPI url */
             id: string;
-            /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
-            embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
         }
@@ -1074,8 +1068,6 @@ export declare namespace ContentTree {
             type: "custom-code-component";
             /** Id taken from the CAPI url */
             id: string;
-            /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
-            embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
             /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -252,7 +252,7 @@ export declare namespace ContentTree {
         children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
         columnSettings: TableColumnSettings[];
     }
-    type Attributes = {
+    type CustomCodeComponentAttributes = {
         [key: string]: string | boolean | undefined;
     };
     interface CustomCodeComponent extends Node {
@@ -269,7 +269,7 @@ export declare namespace ContentTree {
         /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
         attributesLastModified: string;
         /** Configuration data to be passed to the component. */
-        attributes: Attributes;
+        attributes: CustomCodeComponentAttributes;
     }
     namespace full {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
@@ -525,7 +525,7 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        type Attributes = {
+        type CustomCodeComponentAttributes = {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
@@ -542,7 +542,7 @@ export declare namespace ContentTree {
             /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
             attributesLastModified: string;
             /** Configuration data to be passed to the component. */
-            attributes: Attributes;
+            attributes: CustomCodeComponentAttributes;
         }
     }
     namespace transit {
@@ -794,7 +794,7 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        type Attributes = {
+        type CustomCodeComponentAttributes = {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
@@ -1060,7 +1060,7 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        type Attributes = {
+        type CustomCodeComponentAttributes = {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
@@ -1077,7 +1077,7 @@ export declare namespace ContentTree {
             /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
             attributesLastModified?: string;
             /** Configuration data to be passed to the component. */
-            attributes?: Attributes;
+            attributes?: CustomCodeComponentAttributes;
         }
     }
 }

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -252,23 +252,28 @@ export declare namespace ContentTree {
         children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
         columnSettings: TableColumnSettings[];
     }
-    interface CustomCodeComponent extends Parent {
+    interface CccFallbackText extends Node {
+        type: 'ccc-fallback-text';
+        children: Paragraph[];
+    }
+    type CccAttributes = {
+        [key: string]: string | boolean | undefined;
+    };
+    interface CustomCodeComponent extends Node {
         type: "custom-code-component";
+        id: string;
+        embedded: boolean;
+        /** How the component should be presented in the article page according to the column layout system */
+        layoutWidth: LayoutWidth;
         /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
         path: string;
         /** Semantic version of the code of the component, e.g. "^0.3.5". */
         versionRange: string;
         /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
         attributesLastModified: string;
-        /** A unique identifier for this instance */
-        id: string;
-        /** How the component should be presented in the article page according to the column layout system */
-        layoutWidth: LayoutWidth;
         /** Configuration data to be passed to the component. */
-        attributes: {
-            [key: string]: string | boolean | undefined;
-        };
-        children: (ImageSet | Paragraph | CustomCodeComponent)[];
+        attributes: CccAttributes;
+        children: (ImageSet | CccFallbackText)[];
     }
     namespace full {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
@@ -524,23 +529,28 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CustomCodeComponent extends Parent {
+        interface CccFallbackText extends Node {
+            type: 'ccc-fallback-text';
+            children: Paragraph[];
+        }
+        type CccAttributes = {
+            [key: string]: string | boolean | undefined;
+        };
+        interface CustomCodeComponent extends Node {
             type: "custom-code-component";
+            id: string;
+            embedded: boolean;
+            /** How the component should be presented in the article page according to the column layout system */
+            layoutWidth: LayoutWidth;
             /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
             path: string;
             /** Semantic version of the code of the component, e.g. "^0.3.5". */
             versionRange: string;
             /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
             attributesLastModified: string;
-            /** A unique identifier for this instance */
-            id: string;
-            /** How the component should be presented in the article page according to the column layout system */
-            layoutWidth: LayoutWidth;
             /** Configuration data to be passed to the component. */
-            attributes: {
-                [key: string]: string | boolean | undefined;
-            };
-            children: (ImageSet | Paragraph | CustomCodeComponent)[];
+            attributes: CccAttributes;
+            children: (ImageSet | CccFallbackText)[];
         }
     }
     namespace transit {
@@ -792,23 +802,19 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CustomCodeComponent extends Parent {
+        interface CccFallbackText extends Node {
+            type: 'ccc-fallback-text';
+            children: Paragraph[];
+        }
+        type CccAttributes = {
+            [key: string]: string | boolean | undefined;
+        };
+        interface CustomCodeComponent extends Node {
             type: "custom-code-component";
-            /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
-            path: string;
-            /** Semantic version of the code of the component, e.g. "^0.3.5". */
-            versionRange: string;
-            /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
-            attributesLastModified: string;
-            /** A unique identifier for this instance */
             id: string;
+            embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
-            /** Configuration data to be passed to the component. */
-            attributes: {
-                [key: string]: string | boolean | undefined;
-            };
-            children: (ImageSet | Paragraph | CustomCodeComponent)[];
         }
     }
     namespace loose {
@@ -1065,23 +1071,28 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CustomCodeComponent extends Parent {
+        interface CccFallbackText extends Node {
+            type: 'ccc-fallback-text';
+            children: Paragraph[];
+        }
+        type CccAttributes = {
+            [key: string]: string | boolean | undefined;
+        };
+        interface CustomCodeComponent extends Node {
             type: "custom-code-component";
-            /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
-            path: string;
-            /** Semantic version of the code of the component, e.g. "^0.3.5". */
-            versionRange: string;
-            /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
-            attributesLastModified: string;
-            /** A unique identifier for this instance */
             id: string;
+            embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
+            /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
+            path?: string;
+            /** Semantic version of the code of the component, e.g. "^0.3.5". */
+            versionRange?: string;
+            /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
+            attributesLastModified?: string;
             /** Configuration data to be passed to the component. */
-            attributes: {
-                [key: string]: string | boolean | undefined;
-            };
-            children: (ImageSet | Paragraph | CustomCodeComponent)[];
+            attributes?: CccAttributes;
+            children?: (ImageSet | CccFallbackText)[];
         }
     }
 }

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -252,10 +252,6 @@ export declare namespace ContentTree {
         children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
         columnSettings: TableColumnSettings[];
     }
-    interface CccFallbackText extends Node {
-        type: 'ccc-fallback-text';
-        children: Paragraph[];
-    }
     type Attributes = {
         [key: string]: string | boolean | undefined;
     };
@@ -276,7 +272,6 @@ export declare namespace ContentTree {
         attributesLastModified: string;
         /** Configuration data to be passed to the component. */
         attributes: Attributes;
-        children: (ImageSet | CccFallbackText)[];
     }
     namespace full {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
@@ -532,10 +527,6 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CccFallbackText extends Node {
-            type: 'ccc-fallback-text';
-            children: Paragraph[];
-        }
         type Attributes = {
             [key: string]: string | boolean | undefined;
         };
@@ -556,7 +547,6 @@ export declare namespace ContentTree {
             attributesLastModified: string;
             /** Configuration data to be passed to the component. */
             attributes: Attributes;
-            children: (ImageSet | CccFallbackText)[];
         }
     }
     namespace transit {
@@ -807,10 +797,6 @@ export declare namespace ContentTree {
             responsiveStyle: 'overflow' | 'flat' | 'scroll';
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
-        }
-        interface CccFallbackText extends Node {
-            type: 'ccc-fallback-text';
-            children: Paragraph[];
         }
         type Attributes = {
             [key: string]: string | boolean | undefined;
@@ -1080,10 +1066,6 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CccFallbackText extends Node {
-            type: 'ccc-fallback-text';
-            children: Paragraph[];
-        }
         type Attributes = {
             [key: string]: string | boolean | undefined;
         };
@@ -1104,7 +1086,6 @@ export declare namespace ContentTree {
             attributesLastModified?: string;
             /** Configuration data to be passed to the component. */
             attributes?: Attributes;
-            children?: (ImageSet | CccFallbackText)[];
         }
     }
 }

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -252,11 +252,11 @@ export declare namespace ContentTree {
         children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
         columnSettings: TableColumnSettings[];
     }
-    interface CccFallbackText extends Node {
-        type: 'ccc-fallback-text';
+    interface FallbackText extends Node {
+        type: 'fallback-text';
         children: Paragraph[];
     }
-    type CccAttributes = {
+    type Attributes = {
         [key: string]: string | boolean | undefined;
     };
     interface CustomCodeComponent extends Node {
@@ -272,8 +272,8 @@ export declare namespace ContentTree {
         /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
         attributesLastModified: string;
         /** Configuration data to be passed to the component. */
-        attributes: CccAttributes;
-        children: (ImageSet | CccFallbackText)[];
+        attributes: Attributes;
+        children: (ImageSet | FallbackText)[];
     }
     namespace full {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
@@ -529,11 +529,11 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CccFallbackText extends Node {
-            type: 'ccc-fallback-text';
+        interface FallbackText extends Node {
+            type: 'fallback-text';
             children: Paragraph[];
         }
-        type CccAttributes = {
+        type Attributes = {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
@@ -549,8 +549,8 @@ export declare namespace ContentTree {
             /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
             attributesLastModified: string;
             /** Configuration data to be passed to the component. */
-            attributes: CccAttributes;
-            children: (ImageSet | CccFallbackText)[];
+            attributes: Attributes;
+            children: (ImageSet | FallbackText)[];
         }
     }
     namespace transit {
@@ -802,11 +802,11 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CccFallbackText extends Node {
-            type: 'ccc-fallback-text';
+        interface FallbackText extends Node {
+            type: 'fallback-text';
             children: Paragraph[];
         }
-        type CccAttributes = {
+        type Attributes = {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
@@ -1071,11 +1071,11 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface CccFallbackText extends Node {
-            type: 'ccc-fallback-text';
+        interface FallbackText extends Node {
+            type: 'fallback-text';
             children: Paragraph[];
         }
-        type CccAttributes = {
+        type Attributes = {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
@@ -1091,8 +1091,8 @@ export declare namespace ContentTree {
             /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
             attributesLastModified?: string;
             /** Configuration data to be passed to the component. */
-            attributes?: CccAttributes;
-            children?: (ImageSet | CccFallbackText)[];
+            attributes?: Attributes;
+            children?: (ImageSet | FallbackText)[];
         }
     }
 }

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -252,8 +252,8 @@ export declare namespace ContentTree {
         children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
         columnSettings: TableColumnSettings[];
     }
-    interface FallbackText extends Node {
-        type: 'fallback-text';
+    interface CccFallbackText extends Node {
+        type: 'ccc-fallback-text';
         children: Paragraph[];
     }
     type Attributes = {
@@ -276,7 +276,7 @@ export declare namespace ContentTree {
         attributesLastModified: string;
         /** Configuration data to be passed to the component. */
         attributes: Attributes;
-        children: (ImageSet | FallbackText)[];
+        children: (ImageSet | CccFallbackText)[];
     }
     namespace full {
         type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
@@ -532,8 +532,8 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface FallbackText extends Node {
-            type: 'fallback-text';
+        interface CccFallbackText extends Node {
+            type: 'ccc-fallback-text';
             children: Paragraph[];
         }
         type Attributes = {
@@ -556,7 +556,7 @@ export declare namespace ContentTree {
             attributesLastModified: string;
             /** Configuration data to be passed to the component. */
             attributes: Attributes;
-            children: (ImageSet | FallbackText)[];
+            children: (ImageSet | CccFallbackText)[];
         }
     }
     namespace transit {
@@ -808,8 +808,8 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface FallbackText extends Node {
-            type: 'fallback-text';
+        interface CccFallbackText extends Node {
+            type: 'ccc-fallback-text';
             children: Paragraph[];
         }
         type Attributes = {
@@ -1080,8 +1080,8 @@ export declare namespace ContentTree {
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
         }
-        interface FallbackText extends Node {
-            type: 'fallback-text';
+        interface CccFallbackText extends Node {
+            type: 'ccc-fallback-text';
             children: Paragraph[];
         }
         type Attributes = {
@@ -1104,7 +1104,7 @@ export declare namespace ContentTree {
             attributesLastModified?: string;
             /** Configuration data to be passed to the component. */
             attributes?: Attributes;
-            children?: (ImageSet | FallbackText)[];
+            children?: (ImageSet | CccFallbackText)[];
         }
     }
 }

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -260,8 +260,11 @@ export declare namespace ContentTree {
         [key: string]: string | boolean | undefined;
     };
     interface CustomCodeComponent extends Node {
+        /** Component type */
         type: "custom-code-component";
+        /** Id taken from the CAPI url */
         id: string;
+        /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
         embedded: boolean;
         /** How the component should be presented in the article page according to the column layout system */
         layoutWidth: LayoutWidth;
@@ -269,7 +272,7 @@ export declare namespace ContentTree {
         path: string;
         /** Semantic version of the code of the component, e.g. "^0.3.5". */
         versionRange: string;
-        /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
+        /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
         attributesLastModified: string;
         /** Configuration data to be passed to the component. */
         attributes: Attributes;
@@ -537,8 +540,11 @@ export declare namespace ContentTree {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
+            /** Component type */
             type: "custom-code-component";
+            /** Id taken from the CAPI url */
             id: string;
+            /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
             embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
@@ -546,7 +552,7 @@ export declare namespace ContentTree {
             path: string;
             /** Semantic version of the code of the component, e.g. "^0.3.5". */
             versionRange: string;
-            /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
+            /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
             attributesLastModified: string;
             /** Configuration data to be passed to the component. */
             attributes: Attributes;
@@ -810,8 +816,11 @@ export declare namespace ContentTree {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
+            /** Component type */
             type: "custom-code-component";
+            /** Id taken from the CAPI url */
             id: string;
+            /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
             embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
@@ -1079,8 +1088,11 @@ export declare namespace ContentTree {
             [key: string]: string | boolean | undefined;
         };
         interface CustomCodeComponent extends Node {
+            /** Component type */
             type: "custom-code-component";
+            /** Id taken from the CAPI url */
             id: string;
+            /** Whether the component contains external fields that will be unrolled and returned in the article's "embeds" array */
             embedded: boolean;
             /** How the component should be presented in the article page according to the column layout system */
             layoutWidth: LayoutWidth;
@@ -1088,7 +1100,7 @@ export declare namespace ContentTree {
             path?: string;
             /** Semantic version of the code of the component, e.g. "^0.3.5". */
             versionRange?: string;
-            /** Last date-time where the attributes for this block were modified, in ISO-8601 format. */
+            /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
             attributesLastModified?: string;
             /** Configuration data to be passed to the component. */
             attributes?: Attributes;

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -121,9 +121,11 @@
             "properties": {
                 "data": {},
                 "embedded": {
+                    "description": "Whether the component contains external fields that will be unrolled and returned in the article's \"embeds\" array",
                     "type": "boolean"
                 },
                 "id": {
+                    "description": "Id taken from the CAPI url",
                     "type": "string"
                 },
                 "layoutWidth": {
@@ -132,6 +134,7 @@
                 },
                 "type": {
                     "const": "custom-code-component",
+                    "description": "Component type",
                     "type": "string"
                 }
             },

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -119,55 +119,19 @@
         },
         "ContentTree.transit.CustomCodeComponent": {
             "properties": {
-                "attributes": {
-                    "additionalProperties": {
-                        "type": [
-                            "string",
-                            "boolean"
-                        ]
-                    },
-                    "description": "Configuration data to be passed to the component.",
-                    "type": "object"
-                },
-                "attributesLastModified": {
-                    "description": "Last date-time where the attributes for this block were modified, in ISO-8601 format.",
-                    "type": "string"
-                },
-                "children": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/ContentTree.transit.Paragraph"
-                            },
-                            {
-                                "$ref": "#/definitions/ContentTree.transit.ImageSet"
-                            },
-                            {
-                                "$ref": "#/definitions/ContentTree.transit.CustomCodeComponent"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                },
                 "data": {},
+                "embedded": {
+                    "type": "boolean"
+                },
                 "id": {
-                    "description": "A unique identifier for this instance",
                     "type": "string"
                 },
                 "layoutWidth": {
                     "$ref": "#/definitions/ContentTree.transit.LayoutWidth",
                     "description": "How the component should be presented in the article page according to the column layout system"
                 },
-                "path": {
-                    "description": "Repository for the code of the component in the format \"[github org]/[github repo]/[component name]\".",
-                    "type": "string"
-                },
                 "type": {
                     "const": "custom-code-component",
-                    "type": "string"
-                },
-                "versionRange": {
-                    "description": "Semantic version of the code of the component, e.g. \"^0.3.5\".",
                     "type": "string"
                 }
             },

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -120,10 +120,6 @@
         "ContentTree.transit.CustomCodeComponent": {
             "properties": {
                 "data": {},
-                "embedded": {
-                    "description": "Whether the component contains external fields that will be unrolled and returned in the article's \"embeds\" array",
-                    "type": "boolean"
-                },
                 "id": {
                     "description": "Id taken from the CAPI url",
                     "type": "string"

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -136,6 +136,22 @@
             },
             "type": "object"
         },
+        "ContentTree.full.CccFallbackText": {
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.Paragraph"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "ccc-fallback-text",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ContentTree.full.CustomCodeComponent": {
             "properties": {
                 "attributes": {
@@ -156,21 +172,20 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/ContentTree.full.Paragraph"
-                            },
-                            {
                                 "$ref": "#/definitions/ContentTree.full.ImageSet"
                             },
                             {
-                                "$ref": "#/definitions/ContentTree.full.CustomCodeComponent"
+                                "$ref": "#/definitions/ContentTree.full.CccFallbackText"
                             }
                         ]
                     },
                     "type": "array"
                 },
                 "data": {},
+                "embedded": {
+                    "type": "boolean"
+                },
                 "id": {
-                    "description": "A unique identifier for this instance",
                     "type": "string"
                 },
                 "layoutWidth": {

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -149,7 +149,7 @@
                     "type": "object"
                 },
                 "attributesLastModified": {
-                    "description": "Last date-time where the attributes for this block were modified, in ISO-8601 format.",
+                    "description": "Last date-time when the attributes for this block were modified, in ISO-8601 format.",
                     "type": "string"
                 },
                 "children": {
@@ -167,9 +167,11 @@
                 },
                 "data": {},
                 "embedded": {
+                    "description": "Whether the component contains external fields that will be unrolled and returned in the article's \"embeds\" array",
                     "type": "boolean"
                 },
                 "id": {
+                    "description": "Id taken from the CAPI url",
                     "type": "string"
                 },
                 "layoutWidth": {
@@ -182,6 +184,7 @@
                 },
                 "type": {
                     "const": "custom-code-component",
+                    "description": "Component type",
                     "type": "string"
                 },
                 "versionRange": {

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -136,22 +136,6 @@
             },
             "type": "object"
         },
-        "ContentTree.full.CccFallbackText": {
-            "properties": {
-                "children": {
-                    "items": {
-                        "$ref": "#/definitions/ContentTree.full.Paragraph"
-                    },
-                    "type": "array"
-                },
-                "data": {},
-                "type": {
-                    "const": "ccc-fallback-text",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "ContentTree.full.CustomCodeComponent": {
             "properties": {
                 "attributes": {
@@ -175,7 +159,7 @@
                                 "$ref": "#/definitions/ContentTree.full.ImageSet"
                             },
                             {
-                                "$ref": "#/definitions/ContentTree.full.CccFallbackText"
+                                "$ref": "#/definitions/ContentTree.full.FallbackText"
                             }
                         ]
                     },
@@ -218,6 +202,22 @@
                 "data": {},
                 "type": {
                     "const": "emphasis",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ContentTree.full.FallbackText": {
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.Paragraph"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "fallback-text",
                     "type": "string"
                 }
             },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -153,10 +153,6 @@
                     "type": "string"
                 },
                 "data": {},
-                "embedded": {
-                    "description": "Whether the component contains external fields that will be unrolled and returned in the article's \"embeds\" array",
-                    "type": "boolean"
-                },
                 "id": {
                     "description": "Id taken from the CAPI url",
                     "type": "string"

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -136,6 +136,22 @@
             },
             "type": "object"
         },
+        "ContentTree.full.CccFallbackText": {
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.Paragraph"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "ccc-fallback-text",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ContentTree.full.CustomCodeComponent": {
             "properties": {
                 "attributes": {
@@ -159,7 +175,7 @@
                                 "$ref": "#/definitions/ContentTree.full.ImageSet"
                             },
                             {
-                                "$ref": "#/definitions/ContentTree.full.FallbackText"
+                                "$ref": "#/definitions/ContentTree.full.CccFallbackText"
                             }
                         ]
                     },
@@ -205,22 +221,6 @@
                 "data": {},
                 "type": {
                     "const": "emphasis",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ContentTree.full.FallbackText": {
-            "properties": {
-                "children": {
-                    "items": {
-                        "$ref": "#/definitions/ContentTree.full.Paragraph"
-                    },
-                    "type": "array"
-                },
-                "data": {},
-                "type": {
-                    "const": "fallback-text",
                     "type": "string"
                 }
             },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -136,22 +136,6 @@
             },
             "type": "object"
         },
-        "ContentTree.full.CccFallbackText": {
-            "properties": {
-                "children": {
-                    "items": {
-                        "$ref": "#/definitions/ContentTree.full.Paragraph"
-                    },
-                    "type": "array"
-                },
-                "data": {},
-                "type": {
-                    "const": "ccc-fallback-text",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "ContentTree.full.CustomCodeComponent": {
             "properties": {
                 "attributes": {
@@ -167,19 +151,6 @@
                 "attributesLastModified": {
                     "description": "Last date-time when the attributes for this block were modified, in ISO-8601 format.",
                     "type": "string"
-                },
-                "children": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/ContentTree.full.ImageSet"
-                            },
-                            {
-                                "$ref": "#/definitions/ContentTree.full.CccFallbackText"
-                            }
-                        ]
-                    },
-                    "type": "array"
                 },
                 "data": {},
                 "embedded": {

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -140,9 +140,11 @@
             "properties": {
                 "data": {},
                 "embedded": {
+                    "description": "Whether the component contains external fields that will be unrolled and returned in the article's \"embeds\" array",
                     "type": "boolean"
                 },
                 "id": {
+                    "description": "Id taken from the CAPI url",
                     "type": "string"
                 },
                 "layoutWidth": {
@@ -151,6 +153,7 @@
                 },
                 "type": {
                     "const": "custom-code-component",
+                    "description": "Component type",
                     "type": "string"
                 }
             },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -139,10 +139,6 @@
         "ContentTree.transit.CustomCodeComponent": {
             "properties": {
                 "data": {},
-                "embedded": {
-                    "description": "Whether the component contains external fields that will be unrolled and returned in the article's \"embeds\" array",
-                    "type": "boolean"
-                },
                 "id": {
                     "description": "Id taken from the CAPI url",
                     "type": "string"

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -138,55 +138,19 @@
         },
         "ContentTree.transit.CustomCodeComponent": {
             "properties": {
-                "attributes": {
-                    "additionalProperties": {
-                        "type": [
-                            "string",
-                            "boolean"
-                        ]
-                    },
-                    "description": "Configuration data to be passed to the component.",
-                    "type": "object"
-                },
-                "attributesLastModified": {
-                    "description": "Last date-time where the attributes for this block were modified, in ISO-8601 format.",
-                    "type": "string"
-                },
-                "children": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/ContentTree.transit.Paragraph"
-                            },
-                            {
-                                "$ref": "#/definitions/ContentTree.transit.ImageSet"
-                            },
-                            {
-                                "$ref": "#/definitions/ContentTree.transit.CustomCodeComponent"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                },
                 "data": {},
+                "embedded": {
+                    "type": "boolean"
+                },
                 "id": {
-                    "description": "A unique identifier for this instance",
                     "type": "string"
                 },
                 "layoutWidth": {
                     "$ref": "#/definitions/ContentTree.transit.LayoutWidth",
                     "description": "How the component should be presented in the article page according to the column layout system"
                 },
-                "path": {
-                    "description": "Repository for the code of the component in the format \"[github org]/[github repo]/[component name]\".",
-                    "type": "string"
-                },
                 "type": {
                     "const": "custom-code-component",
-                    "type": "string"
-                },
-                "versionRange": {
-                    "description": "Semantic version of the code of the component, e.g. \"^0.3.5\".",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
This PR does the following

- Changes the transit `CustomCodeComponent` to be the unrolled version
- Removes the children from  `CustomCodeComponent` as they are now in its `bodyXML` rater than attributes.

This is to match the schema defined [here](https://docs.google.com/document/d/1U19N5MA3H36mmweY4Qun-Gs_qd58RgO5fqb-3fd3y6Q/edit?usp=sharing)
