### PR TITLE
Add support for subscript and superscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,28 @@ interface Strikethrough extends Parent {
 
 **Strikethrough** represents a piece of text that has been stricken.
 
+### `Subscript`
+
+```ts
+interface Subscript extends Parent {
+	type: "subscript"
+	children: Phrasing[]
+}
+```
+
+**Subscript** represents a piece of text that has a lowered baseline.
+
+### `Superscript`
+
+```ts
+interface Superscript extends Parent {
+	type: "superscript"
+	children: Phrasing[]
+}
+```
+
+**Superscript** represents a piece of text with a raised baseline.
+
 ### `Link`
 
 ```ts

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -49,6 +49,14 @@ export declare namespace ContentTree {
         type: "strikethrough";
         children: Phrasing[];
     }
+    interface Subscript extends Parent {
+        type: "subscript";
+        children: Phrasing[];
+    }
+    interface Superscript extends Parent {
+        type: "superscript";
+        children: Phrasing[];
+    }
     interface Link extends Parent {
         type: "link";
         url: string;
@@ -320,6 +328,14 @@ export declare namespace ContentTree {
         }
         interface Strikethrough extends Parent {
             type: "strikethrough";
+            children: Phrasing[];
+        }
+        interface Subscript extends Parent {
+            type: "subscript";
+            children: Phrasing[];
+        }
+        interface Superscript extends Parent {
+            type: "superscript";
             children: Phrasing[];
         }
         interface Link extends Parent {
@@ -596,6 +612,14 @@ export declare namespace ContentTree {
             type: "strikethrough";
             children: Phrasing[];
         }
+        interface Subscript extends Parent {
+            type: "subscript";
+            children: Phrasing[];
+        }
+        interface Superscript extends Parent {
+            type: "superscript";
+            children: Phrasing[];
+        }
         interface Link extends Parent {
             type: "link";
             url: string;
@@ -855,6 +879,14 @@ export declare namespace ContentTree {
         }
         interface Strikethrough extends Parent {
             type: "strikethrough";
+            children: Phrasing[];
+        }
+        interface Subscript extends Parent {
+            type: "subscript";
+            children: Phrasing[];
+        }
+        interface Superscript extends Parent {
+            type: "superscript";
             children: Phrasing[];
         }
         interface Link extends Parent {

--- a/libraries/from-bodyxml/index.js
+++ b/libraries/from-bodyxml/index.js
@@ -89,6 +89,22 @@ export let defaultTransformers = {
 		}
 	},
 	/**
+	 * @type {Transformer<ContentTree.transit.Subscript>}
+	 */
+	sub(sub) {
+		return {
+			type: "subscript",
+		}
+	},
+	/**
+	 * @type {Transformer<ContentTree.transit.Superscript>}
+	 */
+	sup(sup) {
+		return {
+			type: "superscript",
+		}
+	},
+	/**
 	 * @type {Transformer<ContentTree.transit.Break>}
 	 */
 	br(br) {


### PR DESCRIPTION
- The Spark team are working on a piece of work to add support to subscript and superscript to Spark
- This commit contains changes to Content Tree to add support for subscript and superscript text, via the <sup> and <sub> tags