### PR TITLE
fix: add Flourish as a valid body block

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ type BodyBlock =
 	| Paragraph
 	| Heading
 	| ImageSet
+	| Flourish
 	| BigNumber
 	| CustomCodeComponent
 	| Layout

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -1,5 +1,5 @@
 export declare namespace ContentTree {
-    type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
+    type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
     type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
     type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
     interface Node {
@@ -272,7 +272,7 @@ export declare namespace ContentTree {
         attributes: CustomCodeComponentAttributes;
     }
     namespace full {
-        type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -546,7 +546,7 @@ export declare namespace ContentTree {
         }
     }
     namespace transit {
-        type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -807,7 +807,7 @@ export declare namespace ContentTree {
         }
     }
     namespace loose {
-        type BodyBlock = Paragraph | Heading | ImageSet | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -67,6 +67,9 @@
                     "$ref": "#/definitions/ContentTree.transit.ImageSet"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.transit.Flourish"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.transit.BigNumber"
                 },
                 {
@@ -147,6 +150,77 @@
                 "data": {},
                 "type": {
                     "const": "emphasis",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ContentTree.transit.Flourish": {
+            "properties": {
+                "data": {},
+                "description": {
+                    "type": "string"
+                },
+                "fallbackImage": {
+                    "properties": {
+                        "format": {
+                            "enum": [
+                                "desktop",
+                                "mobile",
+                                "square",
+                                "square-ftedit",
+                                "standard",
+                                "standard-inline",
+                                "wide"
+                            ],
+                            "type": "string"
+                        },
+                        "height": {
+                            "type": "number"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "sourceSet": {
+                            "items": {
+                                "properties": {
+                                    "dpr": {
+                                        "type": "number"
+                                    },
+                                    "url": {
+                                        "type": "string"
+                                    },
+                                    "width": {
+                                        "type": "number"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "width": {
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "flourishType": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "layoutWidth": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "flourish",
                     "type": "string"
                 }
             },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -86,6 +86,9 @@
                     "$ref": "#/definitions/ContentTree.full.ImageSet"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.full.Flourish"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.full.BigNumber"
                 },
                 {
@@ -188,6 +191,77 @@
                 "data": {},
                 "type": {
                     "const": "emphasis",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ContentTree.full.Flourish": {
+            "properties": {
+                "data": {},
+                "description": {
+                    "type": "string"
+                },
+                "fallbackImage": {
+                    "properties": {
+                        "format": {
+                            "enum": [
+                                "desktop",
+                                "mobile",
+                                "square",
+                                "square-ftedit",
+                                "standard",
+                                "standard-inline",
+                                "wide"
+                            ],
+                            "type": "string"
+                        },
+                        "height": {
+                            "type": "number"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "sourceSet": {
+                            "items": {
+                                "properties": {
+                                    "dpr": {
+                                        "type": "number"
+                                    },
+                                    "url": {
+                                        "type": "string"
+                                    },
+                                    "width": {
+                                        "type": "number"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "width": {
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "flourishType": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "layoutWidth": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "flourish",
                     "type": "string"
                 }
             },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -86,6 +86,9 @@
                     "$ref": "#/definitions/ContentTree.transit.ImageSet"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.transit.Flourish"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.transit.BigNumber"
                 },
                 {
@@ -166,6 +169,77 @@
                 "data": {},
                 "type": {
                     "const": "emphasis",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ContentTree.transit.Flourish": {
+            "properties": {
+                "data": {},
+                "description": {
+                    "type": "string"
+                },
+                "fallbackImage": {
+                    "properties": {
+                        "format": {
+                            "enum": [
+                                "desktop",
+                                "mobile",
+                                "square",
+                                "square-ftedit",
+                                "standard",
+                                "standard-inline",
+                                "wide"
+                            ],
+                            "type": "string"
+                        },
+                        "height": {
+                            "type": "number"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "sourceSet": {
+                            "items": {
+                                "properties": {
+                                    "dpr": {
+                                        "type": "number"
+                                    },
+                                    "url": {
+                                        "type": "string"
+                                    },
+                                    "width": {
+                                        "type": "number"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "width": {
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "flourishType": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "layoutWidth": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "flourish",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
The `BodyBlock` type was missing `Flourish` as a valid option. This meant they weren't included in the generated JSON schemas