### PR TITLE
Remove smoke test from main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,3 @@ workflows:
                 - main
     jobs:
       - smoke-test
-  main:
-    jobs:
-      - smoke-test


### PR DESCRIPTION
There's no point running it on builds until we know it passes.