### PR TITLE
Fix CustomCodeComponent Unmarshalling in Go

### DIFF
--- a/content_tree.go
+++ b/content_tree.go
@@ -539,6 +539,7 @@ func (n *BodyBlock) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &v); err != nil {
 			return err
 		}
+		n.CustomCodeComponent = &v
 	default:
 		return fmt.Errorf("failed to unmarshal BodyBlock from %s: %w", data, ErrUnmarshalInvalidNode)
 	}


### PR DESCRIPTION
This PR fixes the issue where the CustomCodeComponent wasn't assigned during JSON unmarshalling of the content tree. Now, the unmarshalled component is correctly set on the node.