### PR TITLE
Remove embedded property from videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,6 @@ interface BigNumber extends Node {
 interface Video extends Node {
 	type: "video"
 	id: string
-	embedded: boolean
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -165,7 +165,6 @@ export declare namespace ContentTree {
     interface Video extends Node {
         type: "video";
         id: string;
-        embedded: boolean;
     }
     interface YoutubeVideo extends Node {
         type: "youtube-video";
@@ -438,7 +437,6 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
-            embedded: boolean;
         }
         interface YoutubeVideo extends Node {
             type: "youtube-video";
@@ -709,7 +707,6 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
-            embedded: boolean;
         }
         interface YoutubeVideo extends Node {
             type: "youtube-video";
@@ -973,7 +970,6 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
-            embedded: boolean;
         }
         interface YoutubeVideo extends Node {
             type: "youtube-video";

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -1143,9 +1143,6 @@
             "additionalProperties": false,
             "properties": {
                 "data": {},
-                "embedded": {
-                    "type": "boolean"
-                },
                 "id": {
                     "type": "string"
                 },
@@ -1155,7 +1152,6 @@
                 }
             },
             "required": [
-                "embedded",
                 "id",
                 "type"
             ],

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -1865,9 +1865,6 @@
             "additionalProperties": false,
             "properties": {
                 "data": {},
-                "embedded": {
-                    "type": "boolean"
-                },
                 "id": {
                     "type": "string"
                 },
@@ -1877,7 +1874,6 @@
                 }
             },
             "required": [
-                "embedded",
                 "id",
                 "type"
             ],

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -1168,9 +1168,6 @@
             "additionalProperties": false,
             "properties": {
                 "data": {},
-                "embedded": {
-                    "type": "boolean"
-                },
                 "id": {
                     "type": "string"
                 },
@@ -1180,7 +1177,6 @@
                 }
             },
             "required": [
-                "embedded",
                 "id",
                 "type"
             ],


### PR DESCRIPTION
The `data-embedded` attribute is a hangover from how they used to work in bodyXML. There is currently no way of creating of video that is `embedded: false` in Spark (nor AFAIK has there ever been).

NOTE: this will need to be followed up by an update in cp-content-pipeline to remove the embedded property there (and default the HTML to use `data-embedded={true}` if it's required.