### PR TITLE
Add external title to video

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,10 +535,13 @@ interface BigNumber extends Node {
 interface Video extends Node {
 	type: "video"
 	id: string
+    external title: string
 }
 ```
 
 **Video** represents for an FT video referenced by a URL.
+
+The `title` can be obtained by fetching the Video from the content API.
 
 TODO: Figure out how Clips work, how they are different?
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -165,6 +165,7 @@ export declare namespace ContentTree {
     interface Video extends Node {
         type: "video";
         id: string;
+        title: string;
     }
     interface YoutubeVideo extends Node {
         type: "youtube-video";
@@ -437,6 +438,7 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
+            title: string;
         }
         interface YoutubeVideo extends Node {
             type: "youtube-video";
@@ -970,6 +972,7 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
+            title?: string;
         }
         interface YoutubeVideo extends Node {
             type: "youtube-video";

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -1868,6 +1868,9 @@
                 "id": {
                     "type": "string"
                 },
+                "title": {
+                    "type": "string"
+                },
                 "type": {
                     "const": "video",
                     "type": "string"
@@ -1875,6 +1878,7 @@
             },
             "required": [
                 "id",
+                "title",
                 "type"
             ],
             "type": "object"


### PR DESCRIPTION
FT.com fetches the video object in order to display the video's title

This is currently a [Workaround](https://github.com/Financial-Times/cp-content-pipeline/blob/main/packages/schema/src/resolvers/content-tree/Workarounds.ts#L74), and a [resolver](https://github.com/Financial-Times/cp-content-pipeline/blob/main/packages/schema/src/resolvers/content-tree/references/Video.ts) in cp-content-pipeline - so we should add it to the real Content Tree spec, and remove the workaround