### PR TITLE
Flourish fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ interface Flourish extends Node {
 	flourishType: string
 	description?: string
 	timestamp?: string
-	fallbackImage?: Image
+	external fallbackImage?: Image
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -699,7 +699,6 @@ export declare namespace ContentTree {
             flourishType: string;
             description?: string;
             timestamp?: string;
-            fallbackImage?: Image;
         }
         interface BigNumber extends Node {
             type: "big-number";

--- a/libraries/from-bodyxml/index.js
+++ b/libraries/from-bodyxml/index.js
@@ -257,20 +257,23 @@ export let defaultTransformers = {
    * @type {Transformer<ContentTree.transit.Flourish | ContentTree.transit.Link>}
    */
   [ContentType.content](content) {
+    const id = content.attributes.url ?? "";
+    const uuid = id.split("/").pop();
+
     if (content.attributes["data-asset-type"] == "flourish") {
       return /** @type {ContentTree.transit.Flourish} */ ({
         type: "flourish",
+        id: uuid,
         flourishType: content.attributes["data-flourish-type"] || "",
         layoutWidth: toValidLayoutWidth(
           content.attributes["data-layout-width"] || ""
         ),
         description: content.attributes["alt"] || "",
         timestamp: content.attributes["data-time-stamp"] || "",
-        // fallbackImage -- TODO should this be external in content-tree?
+        children: null,
       });
     }
-    const id = content.attributes.url ?? "";
-    const uuid = id.split("/").pop();
+
     return /** @type {ContentTree.transit.Link} */ ({
       type: "link",
       url: `https://www.ft.com/content/${uuid}`,

--- a/libraries/from-bodyxml/index.js
+++ b/libraries/from-bodyxml/index.js
@@ -249,7 +249,6 @@ export let defaultTransformers = {
     return {
       type: "video",
       id: content.attributes.url ?? "",
-      embedded: content.attributes["data-embedded"] == "true" ? true : false,
       children: null,
     };
   },

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -189,66 +189,6 @@
                 "description": {
                     "type": "string"
                 },
-                "fallbackImage": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "format": {
-                            "enum": [
-                                "desktop",
-                                "mobile",
-                                "square",
-                                "square-ftedit",
-                                "standard",
-                                "standard-inline",
-                                "wide"
-                            ],
-                            "type": "string"
-                        },
-                        "height": {
-                            "type": "number"
-                        },
-                        "id": {
-                            "type": "string"
-                        },
-                        "sourceSet": {
-                            "items": {
-                                "additionalProperties": false,
-                                "properties": {
-                                    "dpr": {
-                                        "type": "number"
-                                    },
-                                    "url": {
-                                        "type": "string"
-                                    },
-                                    "width": {
-                                        "type": "number"
-                                    }
-                                },
-                                "required": [
-                                    "dpr",
-                                    "url",
-                                    "width"
-                                ],
-                                "type": "object"
-                            },
-                            "type": "array"
-                        },
-                        "url": {
-                            "type": "string"
-                        },
-                        "width": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "format",
-                        "height",
-                        "id",
-                        "url",
-                        "width"
-                    ],
-                    "type": "object"
-                },
                 "flourishType": {
                     "type": "string"
                 },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -214,66 +214,6 @@
                 "description": {
                     "type": "string"
                 },
-                "fallbackImage": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "format": {
-                            "enum": [
-                                "desktop",
-                                "mobile",
-                                "square",
-                                "square-ftedit",
-                                "standard",
-                                "standard-inline",
-                                "wide"
-                            ],
-                            "type": "string"
-                        },
-                        "height": {
-                            "type": "number"
-                        },
-                        "id": {
-                            "type": "string"
-                        },
-                        "sourceSet": {
-                            "items": {
-                                "additionalProperties": false,
-                                "properties": {
-                                    "dpr": {
-                                        "type": "number"
-                                    },
-                                    "url": {
-                                        "type": "string"
-                                    },
-                                    "width": {
-                                        "type": "number"
-                                    }
-                                },
-                                "required": [
-                                    "dpr",
-                                    "url",
-                                    "width"
-                                ],
-                                "type": "object"
-                            },
-                            "type": "array"
-                        },
-                        "url": {
-                            "type": "string"
-                        },
-                        "width": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "format",
-                        "height",
-                        "id",
-                        "url",
-                        "width"
-                    ],
-                    "type": "object"
-                },
                 "flourishType": {
                     "type": "string"
                 },

--- a/tools/maketypes/index.js
+++ b/tools/maketypes/index.js
@@ -20,8 +20,9 @@ const full = code.replace(/^(\s+)external (.+)$/gm, "$1$2")
 // in the transit tree, externals must not be present
 const transit = code.replace(/^\s+external (.+:).+$/gm, "")
 // in the loose tree, externals are optional
-const loose = code.replace(/^(\s+)external (.+):(.+)$/gm, "$1$2?:$3")
-
+const loose = code
+	.replace(/^(\s+)external (.+)\?:(.+)$/gm, "$1$2?:$3")
+	.replace(/^(\s+)external (.+):(.+)$/gm, "$1$2?:$3")
 process.stdout.write("export namespace ContentTree {\n")
 // make content-tree nodes available on the root namespace
 process.stdout.write(full.replace(/^/gm, "\t"))


### PR DESCRIPTION
Does a few things to make the flourish transformation work (tested with `1902feb4-9c1c-4c90-ba6b-235e89fda784`)

- Adds `id` and removes `children` from the flourish transformer
- `fallbackImage` was previously optional, but it doesn't really make sense in the transit-tree because it will never be transitted. I've jigged the type-making script to allow us to define an optional external. This will not exist in the transit-tree schema, and will exist in the full schema as optional. Hopefully this makes it a bit more explicit.
- (unrelated) removed `embedded` from video transformer, after #77 