### PR TITLE
More rigourous removal of weird whitespace at the end of paragraph

### DIFF
--- a/libraries/from-bodyxml/index.js
+++ b/libraries/from-bodyxml/index.js
@@ -428,7 +428,7 @@ export function fromXast(bodyxast, transformers = defaultTransformers) {
  * @returns {string}
  */
 function removeWhitespaceBeforeBodyTag(xml) {
-  return xml.replace("</p> </body>", "</p></body>");
+  return xml.replace(/<\/p>\s+<\/body>/gi, '</p></body>');
 }
 
 /** @param {string} bodyxml */


### PR DESCRIPTION
We have some hacky code to remove the weird whitespace we have at the end of lots of articles. FOr some reason that doesn't work on all articles (e.g. https://api-t.ft.com/internalcontent/bb8846e0-4506-433f-86a3-4877ad63fc32) so I've made it a bit more robust with regex whitespace checking


## How to test
- Checkout this branch locally
- `export CONTENT_API_HOST=https://api-t.ft.com`
- `export  CONTENT_API_READ_KEY=<api key>`
- `node libraries/from-bodyxml/validate.js bb8846e0-4506-433f-86a3-4877ad63fc32`

You should get no validation errors