### PR TITLE
feat: add ClipSet to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ type BodyBlock =
 	| Tweet
 	| Video
 	| YoutubeVideo
+	| ClipSet
 	| Text
 ```
 
@@ -550,8 +551,6 @@ interface Video extends Node {
 
 The `title` can be obtained by fetching the Video from the content API.
 
-TODO: Figure out how Clips work, how they are different?
-
 ### `YoutubeVideo`
 
 ```ts
@@ -561,7 +560,75 @@ interface YoutubeVideo extends Node {
 }
 ```
 
+
 **YoutubeVideo** represents a video referenced by a Youtube URL.
+
+### `ClipSet`
+
+```ts
+interface ClipSet extends Node {
+	type: "clip-set"
+	id: string
+	autoplay: boolean
+	loop: boolean
+	muted: boolean
+	layoutWidth: ClipSetLayoutWidth
+	external noAudio: boolean
+	external caption: string
+	external credits: string
+	external description: string
+	external displayTitle: string
+	external systemTitle: string
+	external source: string
+	external contentWarning: string[]
+	external publishedDate: string
+	external subtitle: string
+	external clips: Clip[]
+	external accessibility: ClipAccessibility
+}
+```
+
+```ts
+type Clip = {
+	id: string
+	format: 'standard-inline' | 'mobile'
+	dataSource: ClipSource[]
+	poster: string
+}
+```
+
+```ts
+type ClipSource = {
+	audioCodec: string
+	binaryUrl: string
+	duration: number
+	mediaType: string
+	pixelHeight: number
+	pixelWidth: number
+	videoCodec: string
+}
+```
+
+```ts
+type ClipCaption = {
+	mediaType?: string
+	url?: string
+}
+```
+```ts
+type ClipAccessibility = {
+	captions?: ClipCaption[]
+	transcript?: Body
+}
+```
+
+```ts
+type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">
+```
+
+**ClipSet** represents a short piece of possibly-looping video content for an article.
+
+The external fields are derived from the separately published [ClipSet](https://api.ft.com/schemas/clip-set.json) and [Clip](https://api.ft.com/schemas/clip.json) objects in the Content API.
 
 ### `ScrollyBlock`
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -1,5 +1,5 @@
 export declare namespace ContentTree {
-    type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
+    type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | ClipSet | Text;
     type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
     type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
     interface Node {
@@ -175,6 +175,50 @@ export declare namespace ContentTree {
         type: "youtube-video";
         url: string;
     }
+    interface ClipSet extends Node {
+        type: "clip-set";
+        id: string;
+        autoplay: boolean;
+        loop: boolean;
+        muted: boolean;
+        layoutWidth: ClipSetLayoutWidth;
+        noAudio: boolean;
+        caption: string;
+        credits: string;
+        description: string;
+        displayTitle: string;
+        systemTitle: string;
+        source: string;
+        contentWarning: string[];
+        publishedDate: string;
+        subtitle: string;
+        clips: Clip[];
+        accessibility: ClipAccessibility;
+    }
+    type Clip = {
+        id: string;
+        format: 'standard-inline' | 'mobile';
+        dataSource: ClipSource[];
+        poster: string;
+    };
+    type ClipSource = {
+        audioCodec: string;
+        binaryUrl: string;
+        duration: number;
+        mediaType: string;
+        pixelHeight: number;
+        pixelWidth: number;
+        videoCodec: string;
+    };
+    type ClipCaption = {
+        mediaType?: string;
+        url?: string;
+    };
+    type ClipAccessibility = {
+        captions?: ClipCaption[];
+        transcript?: Body;
+    };
+    type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
     interface ScrollyBlock extends Parent {
         type: "scrolly-block";
         theme: "sans" | "serif";
@@ -279,7 +323,7 @@ export declare namespace ContentTree {
         attributes: CustomCodeComponentAttributes;
     }
     namespace full {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | ClipSet | Text;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -455,6 +499,50 @@ export declare namespace ContentTree {
             type: "youtube-video";
             url: string;
         }
+        interface ClipSet extends Node {
+            type: "clip-set";
+            id: string;
+            autoplay: boolean;
+            loop: boolean;
+            muted: boolean;
+            layoutWidth: ClipSetLayoutWidth;
+            noAudio: boolean;
+            caption: string;
+            credits: string;
+            description: string;
+            displayTitle: string;
+            systemTitle: string;
+            source: string;
+            contentWarning: string[];
+            publishedDate: string;
+            subtitle: string;
+            clips: Clip[];
+            accessibility: ClipAccessibility;
+        }
+        type Clip = {
+            id: string;
+            format: 'standard-inline' | 'mobile';
+            dataSource: ClipSource[];
+            poster: string;
+        };
+        type ClipSource = {
+            audioCodec: string;
+            binaryUrl: string;
+            duration: number;
+            mediaType: string;
+            pixelHeight: number;
+            pixelWidth: number;
+            videoCodec: string;
+        };
+        type ClipCaption = {
+            mediaType?: string;
+            url?: string;
+        };
+        type ClipAccessibility = {
+            captions?: ClipCaption[];
+            transcript?: Body;
+        };
+        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
         interface ScrollyBlock extends Parent {
             type: "scrolly-block";
             theme: "sans" | "serif";
@@ -560,7 +648,7 @@ export declare namespace ContentTree {
         }
     }
     namespace transit {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | ClipSet | Text;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -731,6 +819,38 @@ export declare namespace ContentTree {
             type: "youtube-video";
             url: string;
         }
+        interface ClipSet extends Node {
+            type: "clip-set";
+            id: string;
+            autoplay: boolean;
+            loop: boolean;
+            muted: boolean;
+            layoutWidth: ClipSetLayoutWidth;
+        }
+        type Clip = {
+            id: string;
+            format: 'standard-inline' | 'mobile';
+            dataSource: ClipSource[];
+            poster: string;
+        };
+        type ClipSource = {
+            audioCodec: string;
+            binaryUrl: string;
+            duration: number;
+            mediaType: string;
+            pixelHeight: number;
+            pixelWidth: number;
+            videoCodec: string;
+        };
+        type ClipCaption = {
+            mediaType?: string;
+            url?: string;
+        };
+        type ClipAccessibility = {
+            captions?: ClipCaption[];
+            transcript?: Body;
+        };
+        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
         interface ScrollyBlock extends Parent {
             type: "scrolly-block";
             theme: "sans" | "serif";
@@ -826,7 +946,7 @@ export declare namespace ContentTree {
         }
     }
     namespace loose {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | ClipSet | Text;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -1002,6 +1122,50 @@ export declare namespace ContentTree {
             type: "youtube-video";
             url: string;
         }
+        interface ClipSet extends Node {
+            type: "clip-set";
+            id: string;
+            autoplay: boolean;
+            loop: boolean;
+            muted: boolean;
+            layoutWidth: ClipSetLayoutWidth;
+            noAudio?: boolean;
+            caption?: string;
+            credits?: string;
+            description?: string;
+            displayTitle?: string;
+            systemTitle?: string;
+            source?: string;
+            contentWarning?: string[];
+            publishedDate?: string;
+            subtitle?: string;
+            clips?: Clip[];
+            accessibility?: ClipAccessibility;
+        }
+        type Clip = {
+            id: string;
+            format: 'standard-inline' | 'mobile';
+            dataSource: ClipSource[];
+            poster: string;
+        };
+        type ClipSource = {
+            audioCodec: string;
+            binaryUrl: string;
+            duration: number;
+            mediaType: string;
+            pixelHeight: number;
+            pixelWidth: number;
+            videoCodec: string;
+        };
+        type ClipCaption = {
+            mediaType?: string;
+            url?: string;
+        };
+        type ClipAccessibility = {
+            captions?: ClipCaption[];
+            transcript?: Body;
+        };
+        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
         interface ScrollyBlock extends Parent {
             type: "scrolly-block";
             theme: "sans" | "serif";

--- a/libraries/from-bodyxml/index.js
+++ b/libraries/from-bodyxml/index.js
@@ -8,6 +8,7 @@ let ContentType = {
   content: "http://www.ft.com/ontology/content/Content",
   article: "http://www.ft.com/ontology/content/Article",
   customCodeComponent: "http://www.ft.com/ontology/content/CustomCodeComponent",
+  clipSet: "http://www.ft.com/ontology/content/ClipSet",
 };
 
 /**
@@ -30,6 +31,24 @@ function toValidLayoutWidth(layoutWidth) {
     return /** @type {ContentTree.LayoutWidth} */ (layoutWidth);
   } else {
     return "full-width";
+  }
+}
+
+/**
+ * @param {string} layoutWidth
+ * @returns {ContentTree.ClipSet["layoutWidth"]}
+ */
+function toValidClipLayoutWidth(layoutWidth) {
+  if (
+    [
+      "in-line",
+      "full-grid",
+      "mid-grid",
+    ].includes(layoutWidth)
+  ) {
+    return /** @type {ContentTree.ClipSet["layoutWidth"]} */ (layoutWidth);
+  } else {
+    return "in-line";
   }
 }
 /**
@@ -317,6 +336,24 @@ export let defaultTransformers = {
         layoutWidth: toValidLayoutWidth(
           content.attributes["data-layout-width"] || ""
         ),
+        children: null,
+      };
+    },
+    /**
+   * @type {Transformer<ContentTree.transit.ClipSet>}
+   */
+    [ContentType.clipSet](clip) {
+      const id = clip.attributes.url ?? "";
+      const uuid = id.split("/").pop();
+      return {
+        type: "clip-set",
+        id: uuid ?? "",
+        layoutWidth: toValidClipLayoutWidth(
+          clip.attributes["data-layout-width"] || ""
+        ),
+        autoplay: clip.attributes?.autoplay === "true",
+        loop: clip.attributes?.loop === "true",
+        muted: clip.attributes?.muted === "true",
         children: null,
       };
     },

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -121,6 +121,9 @@
                     "$ref": "#/definitions/ContentTree.transit.YoutubeVideo"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.transit.ClipSet"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.transit.Text"
                 }
             ]
@@ -138,6 +141,48 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.transit.ClipSet": {
+            "additionalProperties": false,
+            "properties": {
+                "autoplay": {
+                    "type": "boolean"
+                },
+                "data": {},
+                "id": {
+                    "type": "string"
+                },
+                "layoutWidth": {
+                    "$ref": "#/definitions/ContentTree.transit.ClipSetLayoutWidth"
+                },
+                "loop": {
+                    "type": "boolean"
+                },
+                "muted": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "const": "clip-set",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "autoplay",
+                "id",
+                "layoutWidth",
+                "loop",
+                "muted",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.ClipSetLayoutWidth": {
+            "enum": [
+                "full-grid",
+                "in-line",
+                "mid-grid"
+            ],
+            "type": "string"
         },
         "ContentTree.transit.CustomCodeComponent": {
             "additionalProperties": false,

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -146,6 +146,9 @@
                     "$ref": "#/definitions/ContentTree.full.YoutubeVideo"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.full.ClipSet"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.full.Text"
                 }
             ]
@@ -163,6 +166,184 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.full.ClipSet": {
+            "additionalProperties": false,
+            "properties": {
+                "accessibility": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "captions": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "mediaType": {
+                                        "type": "string"
+                                    },
+                                    "url": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "transcript": {
+                            "$ref": "#/definitions/ContentTree.full.Body"
+                        }
+                    },
+                    "type": "object"
+                },
+                "autoplay": {
+                    "type": "boolean"
+                },
+                "caption": {
+                    "type": "string"
+                },
+                "clips": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "dataSource": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "audioCodec": {
+                                            "type": "string"
+                                        },
+                                        "binaryUrl": {
+                                            "type": "string"
+                                        },
+                                        "duration": {
+                                            "type": "number"
+                                        },
+                                        "mediaType": {
+                                            "type": "string"
+                                        },
+                                        "pixelHeight": {
+                                            "type": "number"
+                                        },
+                                        "pixelWidth": {
+                                            "type": "number"
+                                        },
+                                        "videoCodec": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "audioCodec",
+                                        "binaryUrl",
+                                        "duration",
+                                        "mediaType",
+                                        "pixelHeight",
+                                        "pixelWidth",
+                                        "videoCodec"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "format": {
+                                "enum": [
+                                    "mobile",
+                                    "standard-inline"
+                                ],
+                                "type": "string"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "poster": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "dataSource",
+                            "format",
+                            "id",
+                            "poster"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "contentWarning": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "credits": {
+                    "type": "string"
+                },
+                "data": {},
+                "description": {
+                    "type": "string"
+                },
+                "displayTitle": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "layoutWidth": {
+                    "$ref": "#/definitions/ContentTree.full.ClipSetLayoutWidth"
+                },
+                "loop": {
+                    "type": "boolean"
+                },
+                "muted": {
+                    "type": "boolean"
+                },
+                "noAudio": {
+                    "type": "boolean"
+                },
+                "publishedDate": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "systemTitle": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "clip-set",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "accessibility",
+                "autoplay",
+                "caption",
+                "clips",
+                "contentWarning",
+                "credits",
+                "description",
+                "displayTitle",
+                "id",
+                "layoutWidth",
+                "loop",
+                "muted",
+                "noAudio",
+                "publishedDate",
+                "source",
+                "subtitle",
+                "systemTitle",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.ClipSetLayoutWidth": {
+            "enum": [
+                "full-grid",
+                "in-line",
+                "mid-grid"
+            ],
+            "type": "string"
         },
         "ContentTree.full.CustomCodeComponent": {
             "additionalProperties": false,

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -146,6 +146,9 @@
                     "$ref": "#/definitions/ContentTree.transit.YoutubeVideo"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.transit.ClipSet"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.transit.Text"
                 }
             ]
@@ -163,6 +166,48 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.transit.ClipSet": {
+            "additionalProperties": false,
+            "properties": {
+                "autoplay": {
+                    "type": "boolean"
+                },
+                "data": {},
+                "id": {
+                    "type": "string"
+                },
+                "layoutWidth": {
+                    "$ref": "#/definitions/ContentTree.transit.ClipSetLayoutWidth"
+                },
+                "loop": {
+                    "type": "boolean"
+                },
+                "muted": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "const": "clip-set",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "autoplay",
+                "id",
+                "layoutWidth",
+                "loop",
+                "muted",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.ClipSetLayoutWidth": {
+            "enum": [
+                "full-grid",
+                "in-line",
+                "mid-grid"
+            ],
+            "type": "string"
         },
         "ContentTree.transit.CustomCodeComponent": {
             "additionalProperties": false,


### PR DESCRIPTION
This is a draft PR for what I think the Clips Schema should be (based on earlier work #86 and what is currently in Workarounds). While the `externals` are still subject to change when we start working on cp-content-pipeline, I think the `transit-tree` properties are in a good place, and can be merged to help with the publishing/migration aspects.

There's a few considerations / changes to how it currently works:

1. Rename `dataLayout` to `layoutWidth` for consistency with other nodes **(this will require a change in cp-content-pipeline / spark / possibly next-home-page / possibly ft-app**)
   a. ClipSet only allows a limited number of layouts, I assume that is intentional?
2. There is a challenge around transcripts, which is currently modelled as a nested body. In the current component in cp-content-pipeline-ui, it is expecting another RichText graphql type (which has a graphql-ish data structure with fields like `raw`, `structured`, `references`). I'm not really sure how we model that in content-tree, or if. If we need content-tree to be different to cp-content-pipeline (i.e. maintain a workaround), that would also mean the UI component itself isn't really transferable.
   a. **DECISION IRL** - we should not replicate the graphql structure in content-tree, but instead make cp-content-pipeline work with this somehow. Some ideas below, but still a bit hazy.
4. Similarly, the `transcript` currently is a <body> with _only_ text. Our current `Body` node in content-tree doesn't allow Text as a top level node - should it? Or should it be a separate thing? 
   a. note - live events also do this, but i've been ignoring them for now!
   b. **DECISION IRL** - Add Text to the allowed bodyNodes (will do this separately)
   
   
## Appendix - Nested Bodies

As mentioned, there is a challenge around the mismatch between how cp-content-pipeline represents nested bodies (GraphQL `RichText` type), and how it is in content tree (`Body` as an attribute). I have a couple of ideas around how we can make cp-content-pipeline work with the Clip Transcript, but someone that knows it better than me might have more thoughts!


1. Change cp-content-pipeline to return `body` instead of the `RichText` type:

  ✅ `bodyTree` in cp-content-pipeline-api more accurately reflects content-tree
  ⚠️ would be a breaking api change
  ❌ i think it works okay for this case, because a transcript is simple. I don't know if it works as well for nested bodies that might have `references` (e.g. if we had the same logic for a CCC fallback that includes images). Maybe there's something around merging the references with the top level ones?? but sounds complicated
   
   
3. `cp-content-pipeline-ui` has a Clip workaround that expects a different format:

```ts
export default function Clip(props: ContentTree.full.ClipSet) {
...
}

export default function ClipWithRichTextTranscript(props: GraphQLProps) {

    const transcript = props.transcript.structured.tree;
    return <Clip ...props, transcript={transcript} />
}
```
✅ not a breaking change maybe?
✅ still have a shared `Clip` component that can be used in e.g. Spark Preview that expects content-tree format
🤔 how does it work with references?
🤔 not sure if it's logically the right place??

## Testing Notes

I have tested the transformer with an article that contains a clip that is currently failing:

```bash
export CONTENT_API_READ_KEY=<redacted>
node libraries/from-bodyxml/validate.js ae37def3-7f15-46d4-8e8d-b3246ad079b4
```