### PR TITLE
feat: add rowSpan and columnSpan to TableCell

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,8 +681,10 @@ interface TableCaption extends Parent {
 }
 
 interface TableCell extends Parent {
-   type: 'table-cell'
+	type: 'table-cell'
 	heading?: boolean
+	columnSpan?: number 
+	rowSpan?: number 
 	children: Phrasing[]
 }
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -228,6 +228,8 @@ export declare namespace ContentTree {
     interface TableCell extends Parent {
         type: 'table-cell';
         heading?: boolean;
+        columnSpan?: number;
+        rowSpan?: number;
         children: Phrasing[];
     }
     interface TableRow extends Parent {
@@ -501,6 +503,8 @@ export declare namespace ContentTree {
         interface TableCell extends Parent {
             type: 'table-cell';
             heading?: boolean;
+            columnSpan?: number;
+            rowSpan?: number;
             children: Phrasing[];
         }
         interface TableRow extends Parent {
@@ -768,6 +772,8 @@ export declare namespace ContentTree {
         interface TableCell extends Parent {
             type: 'table-cell';
             heading?: boolean;
+            columnSpan?: number;
+            rowSpan?: number;
             children: Phrasing[];
         }
         interface TableRow extends Parent {
@@ -1034,6 +1040,8 @@ export declare namespace ContentTree {
         interface TableCell extends Parent {
             type: 'table-cell';
             heading?: boolean;
+            columnSpan?: number;
+            rowSpan?: number;
             children: Phrasing[];
         }
         interface TableRow extends Parent {

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -972,9 +972,15 @@
                     },
                     "type": "array"
                 },
+                "columnSpan": {
+                    "type": "number"
+                },
                 "data": {},
                 "heading": {
                     "type": "boolean"
+                },
+                "rowSpan": {
+                    "type": "number"
                 },
                 "type": {
                     "const": "table-cell",

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -1750,9 +1750,15 @@
                     },
                     "type": "array"
                 },
+                "columnSpan": {
+                    "type": "number"
+                },
                 "data": {},
                 "heading": {
                     "type": "boolean"
+                },
+                "rowSpan": {
+                    "type": "number"
                 },
                 "type": {
                     "const": "table-cell",

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -997,9 +997,15 @@
                     },
                     "type": "array"
                 },
+                "columnSpan": {
+                    "type": "number"
+                },
                 "data": {},
                 "heading": {
                     "type": "boolean"
+                },
+                "rowSpan": {
+                    "type": "number"
                 },
                 "type": {
                     "const": "table-cell",


### PR DESCRIPTION
Whilst Spark/CP-content-pipeline doesn't currently support these, there are a number of older articles that we will want to migrate and retain this information. We also believe it's a worthwhile feature to add support for in the future to Spark.

Discussed in #71 