### PR TITLE
feat: support TableHeader and make sortType optional

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -804,7 +804,7 @@ interface LayoutImage extends Node {
 type TableColumnSettings = {
 	hideOnMobile: boolean
 	sortable: boolean
-	sortType: 'text' | 'number' | 'date' | 'currency' | 'percent'
+	sortType?: 'text' | 'number' | 'date' | 'currency' | 'percent'
 }
 
 type TableLayoutWidth = Extract<LayoutWidth,
@@ -814,6 +814,11 @@ type TableLayoutWidth = Extract<LayoutWidth,
 		| 'inset-right'
 		| 'full-bleed'>
 
+type TableChildren =
+  | [TableCaption, TableBody, TableFooter?]
+  | [TableBody, TableFooter?]
+  | [TableCaption, TableHeader, TableBody, TableFooter?]
+  | [TableHeader, TableBody, TableFooter?]
 
 interface TableCaption extends Parent {
 	type: 'table-caption'
@@ -826,6 +831,11 @@ interface TableCell extends Parent {
 	columnSpan?: number 
 	rowSpan?: number 
 	children: Phrasing[]
+}
+
+interface TableHeader extends Parent {
+	type: 'table-header'
+	children: TableRow[]
 }
 
 interface TableRow extends Parent {
@@ -850,8 +860,8 @@ interface Table extends Parent {
 	layoutWidth: TableLayoutWidth
 	collapseAfterHowManyRows?: number
 	responsiveStyle: 'overflow' | 'flat' | 'scroll'
-	children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody]
 	columnSettings: TableColumnSettings[]
+	children: TableChildren
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -305,9 +305,10 @@ export declare namespace ContentTree {
     type TableColumnSettings = {
         hideOnMobile: boolean;
         sortable: boolean;
-        sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
+        sortType?: 'text' | 'number' | 'date' | 'currency' | 'percent';
     };
     type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
+    type TableChildren = [TableCaption, TableBody, TableFooter?] | [TableBody, TableFooter?] | [TableCaption, TableHeader, TableBody, TableFooter?] | [TableHeader, TableBody, TableFooter?];
     interface TableCaption extends Parent {
         type: 'table-caption';
         children: Phrasing[];
@@ -318,6 +319,10 @@ export declare namespace ContentTree {
         columnSpan?: number;
         rowSpan?: number;
         children: Phrasing[];
+    }
+    interface TableHeader extends Parent {
+        type: 'table-header';
+        children: TableRow[];
     }
     interface TableRow extends Parent {
         type: 'table-row';
@@ -338,8 +343,8 @@ export declare namespace ContentTree {
         layoutWidth: TableLayoutWidth;
         collapseAfterHowManyRows?: number;
         responsiveStyle: 'overflow' | 'flat' | 'scroll';
-        children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
         columnSettings: TableColumnSettings[];
+        children: TableChildren;
     }
     type CustomCodeComponentAttributes = {
         [key: string]: string | boolean | undefined;
@@ -741,9 +746,10 @@ export declare namespace ContentTree {
         type TableColumnSettings = {
             hideOnMobile: boolean;
             sortable: boolean;
-            sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
+            sortType?: 'text' | 'number' | 'date' | 'currency' | 'percent';
         };
         type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
+        type TableChildren = [TableCaption, TableBody, TableFooter?] | [TableBody, TableFooter?] | [TableCaption, TableHeader, TableBody, TableFooter?] | [TableHeader, TableBody, TableFooter?];
         interface TableCaption extends Parent {
             type: 'table-caption';
             children: Phrasing[];
@@ -754,6 +760,10 @@ export declare namespace ContentTree {
             columnSpan?: number;
             rowSpan?: number;
             children: Phrasing[];
+        }
+        interface TableHeader extends Parent {
+            type: 'table-header';
+            children: TableRow[];
         }
         interface TableRow extends Parent {
             type: 'table-row';
@@ -774,8 +784,8 @@ export declare namespace ContentTree {
             layoutWidth: TableLayoutWidth;
             collapseAfterHowManyRows?: number;
             responsiveStyle: 'overflow' | 'flat' | 'scroll';
-            children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
+            children: TableChildren;
         }
         type CustomCodeComponentAttributes = {
             [key: string]: string | boolean | undefined;
@@ -1159,9 +1169,10 @@ export declare namespace ContentTree {
         type TableColumnSettings = {
             hideOnMobile: boolean;
             sortable: boolean;
-            sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
+            sortType?: 'text' | 'number' | 'date' | 'currency' | 'percent';
         };
         type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
+        type TableChildren = [TableCaption, TableBody, TableFooter?] | [TableBody, TableFooter?] | [TableCaption, TableHeader, TableBody, TableFooter?] | [TableHeader, TableBody, TableFooter?];
         interface TableCaption extends Parent {
             type: 'table-caption';
             children: Phrasing[];
@@ -1172,6 +1183,10 @@ export declare namespace ContentTree {
             columnSpan?: number;
             rowSpan?: number;
             children: Phrasing[];
+        }
+        interface TableHeader extends Parent {
+            type: 'table-header';
+            children: TableRow[];
         }
         interface TableRow extends Parent {
             type: 'table-row';
@@ -1192,8 +1207,8 @@ export declare namespace ContentTree {
             layoutWidth: TableLayoutWidth;
             collapseAfterHowManyRows?: number;
             responsiveStyle: 'overflow' | 'flat' | 'scroll';
-            children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
+            children: TableChildren;
         }
         type CustomCodeComponentAttributes = {
             [key: string]: string | boolean | undefined;
@@ -1588,9 +1603,10 @@ export declare namespace ContentTree {
         type TableColumnSettings = {
             hideOnMobile: boolean;
             sortable: boolean;
-            sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
+            sortType?: 'text' | 'number' | 'date' | 'currency' | 'percent';
         };
         type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
+        type TableChildren = [TableCaption, TableBody, TableFooter?] | [TableBody, TableFooter?] | [TableCaption, TableHeader, TableBody, TableFooter?] | [TableHeader, TableBody, TableFooter?];
         interface TableCaption extends Parent {
             type: 'table-caption';
             children: Phrasing[];
@@ -1601,6 +1617,10 @@ export declare namespace ContentTree {
             columnSpan?: number;
             rowSpan?: number;
             children: Phrasing[];
+        }
+        interface TableHeader extends Parent {
+            type: 'table-header';
+            children: TableRow[];
         }
         interface TableRow extends Parent {
             type: 'table-row';
@@ -1621,8 +1641,8 @@ export declare namespace ContentTree {
             layoutWidth: TableLayoutWidth;
             collapseAfterHowManyRows?: number;
             responsiveStyle: 'overflow' | 'flat' | 'scroll';
-            children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
             columnSettings: TableColumnSettings[];
+            children: TableChildren;
         }
         type CustomCodeComponentAttributes = {
             [key: string]: string | boolean | undefined;

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -1242,60 +1242,7 @@
             "additionalProperties": false,
             "properties": {
                 "children": {
-                    "anyOf": [
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableCaption"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableFooter"
-                                }
-                            ],
-                            "maxItems": 3,
-                            "minItems": 3,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableCaption"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                }
-                            ],
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableFooter"
-                                }
-                            ],
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                }
-                            ],
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        }
-                    ]
+                    "$ref": "#/definitions/ContentTree.transit.TableChildren"
                 },
                 "collapseAfterHowManyRows": {
                     "type": "number"
@@ -1323,7 +1270,6 @@
                         },
                         "required": [
                             "hideOnMobile",
-                            "sortType",
                             "sortable"
                         ],
                         "type": "object"
@@ -1436,6 +1382,74 @@
             ],
             "type": "object"
         },
+        "ContentTree.transit.TableChildren": {
+            "anyOf": [
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableCaption"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableCaption"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableHeader"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 4,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableHeader"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                }
+            ]
+        },
         "ContentTree.transit.TableFooter": {
             "additionalProperties": false,
             "properties": {
@@ -1448,6 +1462,27 @@
                 "data": {},
                 "type": {
                     "const": "table-footer",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.TableHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.TableRow"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "table-header",
                     "type": "string"
                 }
             },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -2062,60 +2062,7 @@
             "additionalProperties": false,
             "properties": {
                 "children": {
-                    "anyOf": [
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableCaption"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableBody"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableFooter"
-                                }
-                            ],
-                            "maxItems": 3,
-                            "minItems": 3,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableCaption"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableBody"
-                                }
-                            ],
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableBody"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableFooter"
-                                }
-                            ],
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.full.TableBody"
-                                }
-                            ],
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        }
-                    ]
+                    "$ref": "#/definitions/ContentTree.full.TableChildren"
                 },
                 "collapseAfterHowManyRows": {
                     "type": "number"
@@ -2143,7 +2090,6 @@
                         },
                         "required": [
                             "hideOnMobile",
-                            "sortType",
                             "sortable"
                         ],
                         "type": "object"
@@ -2256,6 +2202,74 @@
             ],
             "type": "object"
         },
+        "ContentTree.full.TableChildren": {
+            "anyOf": [
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableCaption"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableFooter"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableFooter"
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableCaption"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableHeader"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableFooter"
+                        }
+                    ],
+                    "maxItems": 4,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableHeader"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.TableFooter"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                }
+            ]
+        },
         "ContentTree.full.TableFooter": {
             "additionalProperties": false,
             "properties": {
@@ -2268,6 +2282,27 @@
                 "data": {},
                 "type": {
                     "const": "table-footer",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.TableHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.TableRow"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "table-header",
                     "type": "string"
                 }
             },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -1267,60 +1267,7 @@
             "additionalProperties": false,
             "properties": {
                 "children": {
-                    "anyOf": [
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableCaption"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableFooter"
-                                }
-                            ],
-                            "maxItems": 3,
-                            "minItems": 3,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableCaption"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                }
-                            ],
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                },
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableFooter"
-                                }
-                            ],
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "type": "array"
-                        },
-                        {
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/ContentTree.transit.TableBody"
-                                }
-                            ],
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        }
-                    ]
+                    "$ref": "#/definitions/ContentTree.transit.TableChildren"
                 },
                 "collapseAfterHowManyRows": {
                     "type": "number"
@@ -1348,7 +1295,6 @@
                         },
                         "required": [
                             "hideOnMobile",
-                            "sortType",
                             "sortable"
                         ],
                         "type": "object"
@@ -1461,6 +1407,74 @@
             ],
             "type": "object"
         },
+        "ContentTree.transit.TableChildren": {
+            "anyOf": [
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableCaption"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 1,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableCaption"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableHeader"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 4,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableHeader"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableBody"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.TableFooter"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 2,
+                    "type": "array"
+                }
+            ]
+        },
         "ContentTree.transit.TableFooter": {
             "additionalProperties": false,
             "properties": {
@@ -1473,6 +1487,27 @@
                 "data": {},
                 "type": {
                     "const": "table-footer",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.TableHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.TableRow"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "table-header",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
Previously we were relying on the `heading:true` property on TableCell to determine if it's a `<th>` - but we didn't really have anything to indicate the `<thead>`. This meant that consumers like cp-content-pipeline were doing wacky things like pulling out the first row, to put into a th.

Instead, lets be explicit and define a TableHeader.

This change also makes `sortType` optional. It is considered optional in cp-content-pipeline already (presumably because we have tables that don't define it) , so this makes the types in content-tree compatible.

~~cp-content-pipeline update: https://github.com/Financial-Times/cp-content-pipeline/pull/1399~~
~~spark update : TODO~~

**UPDATE:** we have decided for now that Spark/CP will _not_ update to support a TableHeader, as this will involve a breaking change to our table support in CP. We will keep the optional support in content-tree, to support old content.