### PR TITLE
fix: use stricter layoutWidth definition for flourish

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,10 +505,13 @@ interface Tweet extends Node {
 ### `Flourish`
 
 ```ts
+
+type FlourishLayoutWidth =  Extract<LayoutWidth, "full-grid" | "in-line">
+
 interface Flourish extends Node {
 	type: "flourish"
 	id: string
-	layoutWidth: "full-grid" | "in-line"
+	layoutWidth: FlourishLayoutWidth
 	flourishType: string
 	description?: string
 	timestamp?: string
@@ -676,6 +679,14 @@ type TableColumnSettings = {
 	sortType: 'text' | 'number' | 'date' | 'currency' | 'percent'
 }
 
+type TableLayoutWidth = Extract<LayoutWidth,
+		| 'auto'
+		| 'full-grid'
+		| 'inset-left'
+		| 'inset-right'
+		| 'full-bleed'>
+
+
 interface TableCaption extends Parent {
 	type: 'table-caption'
 	children: Phrasing[]
@@ -708,12 +719,7 @@ interface Table extends Parent {
 	type: 'table'
 	stripes: boolean
 	compact: boolean
-	layoutWidth:
-		| 'auto'
-		| 'full-grid'
-		| 'inset-left'
-		| 'inset-right'
-		| 'full-bleed'
+	layoutWidth: TableLayoutWidth
 	collapseAfterHowManyRows?: number
 	responsiveStyle: 'overflow' | 'flat' | 'scroll'
 	children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody]

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -148,10 +148,11 @@ export declare namespace ContentTree {
         type: "tweet";
         html: string;
     }
+    type FlourishLayoutWidth = Extract<LayoutWidth, "full-grid" | "in-line">;
     interface Flourish extends Node {
         type: "flourish";
         id: string;
-        layoutWidth: "full-grid" | "in-line";
+        layoutWidth: FlourishLayoutWidth;
         flourishType: string;
         description?: string;
         timestamp?: string;
@@ -221,6 +222,7 @@ export declare namespace ContentTree {
         sortable: boolean;
         sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
     };
+    type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
     interface TableCaption extends Parent {
         type: 'table-caption';
         children: Phrasing[];
@@ -248,7 +250,7 @@ export declare namespace ContentTree {
         type: 'table';
         stripes: boolean;
         compact: boolean;
-        layoutWidth: 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed';
+        layoutWidth: TableLayoutWidth;
         collapseAfterHowManyRows?: number;
         responsiveStyle: 'overflow' | 'flat' | 'scroll';
         children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
@@ -423,10 +425,11 @@ export declare namespace ContentTree {
             type: "tweet";
             html: string;
         }
+        type FlourishLayoutWidth = Extract<LayoutWidth, "full-grid" | "in-line">;
         interface Flourish extends Node {
             type: "flourish";
             id: string;
-            layoutWidth: "full-grid" | "in-line";
+            layoutWidth: FlourishLayoutWidth;
             flourishType: string;
             description?: string;
             timestamp?: string;
@@ -496,6 +499,7 @@ export declare namespace ContentTree {
             sortable: boolean;
             sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
         };
+        type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
         interface TableCaption extends Parent {
             type: 'table-caption';
             children: Phrasing[];
@@ -523,7 +527,7 @@ export declare namespace ContentTree {
             type: 'table';
             stripes: boolean;
             compact: boolean;
-            layoutWidth: 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed';
+            layoutWidth: TableLayoutWidth;
             collapseAfterHowManyRows?: number;
             responsiveStyle: 'overflow' | 'flat' | 'scroll';
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
@@ -696,10 +700,11 @@ export declare namespace ContentTree {
             id: string;
             type: "tweet";
         }
+        type FlourishLayoutWidth = Extract<LayoutWidth, "full-grid" | "in-line">;
         interface Flourish extends Node {
             type: "flourish";
             id: string;
-            layoutWidth: "full-grid" | "in-line";
+            layoutWidth: FlourishLayoutWidth;
             flourishType: string;
             description?: string;
             timestamp?: string;
@@ -765,6 +770,7 @@ export declare namespace ContentTree {
             sortable: boolean;
             sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
         };
+        type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
         interface TableCaption extends Parent {
             type: 'table-caption';
             children: Phrasing[];
@@ -792,7 +798,7 @@ export declare namespace ContentTree {
             type: 'table';
             stripes: boolean;
             compact: boolean;
-            layoutWidth: 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed';
+            layoutWidth: TableLayoutWidth;
             collapseAfterHowManyRows?: number;
             responsiveStyle: 'overflow' | 'flat' | 'scroll';
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];
@@ -960,10 +966,11 @@ export declare namespace ContentTree {
             type: "tweet";
             html?: string;
         }
+        type FlourishLayoutWidth = Extract<LayoutWidth, "full-grid" | "in-line">;
         interface Flourish extends Node {
             type: "flourish";
             id: string;
-            layoutWidth: "full-grid" | "in-line";
+            layoutWidth: FlourishLayoutWidth;
             flourishType: string;
             description?: string;
             timestamp?: string;
@@ -1033,6 +1040,7 @@ export declare namespace ContentTree {
             sortable: boolean;
             sortType: 'text' | 'number' | 'date' | 'currency' | 'percent';
         };
+        type TableLayoutWidth = Extract<LayoutWidth, 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed'>;
         interface TableCaption extends Parent {
             type: 'table-caption';
             children: Phrasing[];
@@ -1060,7 +1068,7 @@ export declare namespace ContentTree {
             type: 'table';
             stripes: boolean;
             compact: boolean;
-            layoutWidth: 'auto' | 'full-grid' | 'inset-left' | 'inset-right' | 'full-bleed';
+            layoutWidth: TableLayoutWidth;
             collapseAfterHowManyRows?: number;
             responsiveStyle: 'overflow' | 'flat' | 'scroll';
             children: [TableCaption, TableBody, TableFooter] | [TableCaption, TableBody] | [TableBody, TableFooter] | [TableBody];

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -199,11 +199,7 @@
                     "type": "string"
                 },
                 "layoutWidth": {
-                    "enum": [
-                        "full-grid",
-                        "in-line"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/ContentTree.transit.FlourishLayoutWidth"
                 },
                 "timestamp": {
                     "type": "string"
@@ -220,6 +216,13 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.transit.FlourishLayoutWidth": {
+            "enum": [
+                "full-grid",
+                "in-line"
+            ],
+            "type": "string"
         },
         "ContentTree.transit.Heading": {
             "additionalProperties": false,
@@ -892,14 +895,7 @@
                 },
                 "data": {},
                 "layoutWidth": {
-                    "enum": [
-                        "auto",
-                        "full-bleed",
-                        "full-grid",
-                        "inset-left",
-                        "inset-right"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/ContentTree.transit.TableLayoutWidth"
                 },
                 "responsiveStyle": {
                     "enum": [
@@ -1020,6 +1016,16 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.transit.TableLayoutWidth": {
+            "enum": [
+                "auto",
+                "full-bleed",
+                "full-grid",
+                "inset-left",
+                "inset-right"
+            ],
+            "type": "string"
         },
         "ContentTree.transit.TableRow": {
             "additionalProperties": false,

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -310,11 +310,7 @@
                     "type": "string"
                 },
                 "layoutWidth": {
-                    "enum": [
-                        "full-grid",
-                        "in-line"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/ContentTree.full.FlourishLayoutWidth"
                 },
                 "timestamp": {
                     "type": "string"
@@ -331,6 +327,13 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.full.FlourishLayoutWidth": {
+            "enum": [
+                "full-grid",
+                "in-line"
+            ],
+            "type": "string"
         },
         "ContentTree.full.Heading": {
             "additionalProperties": false,
@@ -1670,14 +1673,7 @@
                 },
                 "data": {},
                 "layoutWidth": {
-                    "enum": [
-                        "auto",
-                        "full-bleed",
-                        "full-grid",
-                        "inset-left",
-                        "inset-right"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/ContentTree.full.TableLayoutWidth"
                 },
                 "responsiveStyle": {
                     "enum": [
@@ -1798,6 +1794,16 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.full.TableLayoutWidth": {
+            "enum": [
+                "auto",
+                "full-bleed",
+                "full-grid",
+                "inset-left",
+                "inset-right"
+            ],
+            "type": "string"
         },
         "ContentTree.full.TableRow": {
             "additionalProperties": false,

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -224,11 +224,7 @@
                     "type": "string"
                 },
                 "layoutWidth": {
-                    "enum": [
-                        "full-grid",
-                        "in-line"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/ContentTree.transit.FlourishLayoutWidth"
                 },
                 "timestamp": {
                     "type": "string"
@@ -245,6 +241,13 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.transit.FlourishLayoutWidth": {
+            "enum": [
+                "full-grid",
+                "in-line"
+            ],
+            "type": "string"
         },
         "ContentTree.transit.Heading": {
             "additionalProperties": false,
@@ -917,14 +920,7 @@
                 },
                 "data": {},
                 "layoutWidth": {
-                    "enum": [
-                        "auto",
-                        "full-bleed",
-                        "full-grid",
-                        "inset-left",
-                        "inset-right"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/ContentTree.transit.TableLayoutWidth"
                 },
                 "responsiveStyle": {
                     "enum": [
@@ -1045,6 +1041,16 @@
                 "type"
             ],
             "type": "object"
+        },
+        "ContentTree.transit.TableLayoutWidth": {
+            "enum": [
+                "auto",
+                "full-bleed",
+                "full-grid",
+                "inset-left",
+                "inset-right"
+            ],
+            "type": "string"
         },
         "ContentTree.transit.TableRow": {
             "additionalProperties": false,


### PR DESCRIPTION
The rules for layoutWidth for flourish were unclear, and the schema previously allowed any string.

In Spark Preview, we were passing 'grid' or ''. 
In [cp-content-pipeline-schema](https://github.com/Financial-Times/cp-content-pipeline/blob/main/packages/schema/src/resolvers/content-tree/tagMappings.ts#L267) we were mapping either `grid`, `full-grid` or `article` from bodyXML.
In [cp-content-pipeline-ui](https://github.com/Financial-Times/cp-content-pipeline/blob/main/packages/ui/src/components/content-tree/Flourish/index.tsx#L19), if we see 'full-grid' or 'grid' we expect it to be full-grid, otherwise it is inline.


I think going forward we can limit this to `full-grid` or `in-line`, to be consistent with other layout widths. This change is safe to make without any changes to cp-content-pipeline (although in the future maybe we can tidy up the condition in cp-content-pipeline-ui).

In Spark, we can update `toTransitTree` to ensure it's one of those two values.