### PR TITLE
CI-3004 Rename blockIdentifier to fragmentIdentifier to align with Spark term…

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ interface Heading extends Parent {
 	type: "heading"
 	children: Text[]
 	level: "chapter" | "subheading" | "label"
-	blockIdentifier?: string
+	fragmentIdentifier?: string
 }
 ```
 
@@ -356,7 +356,7 @@ interface ImageSet extends Node {
 	type: "image-set"
 	id: string
 	external picture: ImageSetPicture
-	blockIdentifier?: string
+	fragmentIdentifier?: string
 }
 ```
 
@@ -515,7 +515,7 @@ interface Flourish extends Node {
 	description?: string
 	timestamp?: string
 	external fallbackImage?: Image
-	blockIdentifier?: string
+	fragmentIdentifier?: string
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -36,7 +36,7 @@ export declare namespace ContentTree {
         type: "heading";
         children: Text[];
         level: "chapter" | "subheading" | "label";
-        blockIdentifier?: string;
+        fragmentIdentifier?: string;
     }
     interface Strong extends Parent {
         type: "strong";
@@ -78,7 +78,7 @@ export declare namespace ContentTree {
         type: "image-set";
         id: string;
         picture: ImageSetPicture;
-        blockIdentifier?: string;
+        fragmentIdentifier?: string;
     }
     type ImageSetPicture = {
         layoutWidth: string;
@@ -158,7 +158,7 @@ export declare namespace ContentTree {
         description?: string;
         timestamp?: string;
         fallbackImage?: Image;
-        blockIdentifier?: string;
+        fragmentIdentifier?: string;
     }
     interface BigNumber extends Node {
         type: "big-number";
@@ -314,7 +314,7 @@ export declare namespace ContentTree {
             type: "heading";
             children: Text[];
             level: "chapter" | "subheading" | "label";
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         interface Strong extends Parent {
             type: "strong";
@@ -356,7 +356,7 @@ export declare namespace ContentTree {
             type: "image-set";
             id: string;
             picture: ImageSetPicture;
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         type ImageSetPicture = {
             layoutWidth: string;
@@ -436,7 +436,7 @@ export declare namespace ContentTree {
             description?: string;
             timestamp?: string;
             fallbackImage?: Image;
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         interface BigNumber extends Node {
             type: "big-number";
@@ -593,7 +593,7 @@ export declare namespace ContentTree {
             type: "heading";
             children: Text[];
             level: "chapter" | "subheading" | "label";
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         interface Strong extends Parent {
             type: "strong";
@@ -634,7 +634,7 @@ export declare namespace ContentTree {
         interface ImageSet extends Node {
             type: "image-set";
             id: string;
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         type ImageSetPicture = {
             layoutWidth: string;
@@ -711,7 +711,7 @@ export declare namespace ContentTree {
             flourishType: string;
             description?: string;
             timestamp?: string;
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         interface BigNumber extends Node {
             type: "big-number";
@@ -857,7 +857,7 @@ export declare namespace ContentTree {
             type: "heading";
             children: Text[];
             level: "chapter" | "subheading" | "label";
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         interface Strong extends Parent {
             type: "strong";
@@ -899,7 +899,7 @@ export declare namespace ContentTree {
             type: "image-set";
             id: string;
             picture?: ImageSetPicture;
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         type ImageSetPicture = {
             layoutWidth: string;
@@ -979,7 +979,7 @@ export declare namespace ContentTree {
             description?: string;
             timestamp?: string;
             fallbackImage?: Image;
-            blockIdentifier?: string;
+            fragmentIdentifier?: string;
         }
         interface BigNumber extends Node {
             type: "big-number";

--- a/content_tree.go
+++ b/content_tree.go
@@ -586,15 +586,15 @@ func (n *Emphasis) GetChildren() []Node {
 }
 
 type Flourish struct {
-	Type            string                 `json:"type"`
-	Data            interface{}            `json:"data,omitempty"`
-	Description     string                 `json:"description,omitempty"`
-	FallbackImage   *FlourishFallbackImage `json:"fallbackImage,omitempty"`
-	FlourishType    string                 `json:"flourishType,omitempty"`
-	Id              string                 `json:"id,omitempty"`
-	LayoutWidth     string                 `json:"layoutWidth,omitempty"`
-	Timestamp       string                 `json:"timestamp,omitempty"`
-	BlockIdentifier string                 `json:"blockIdentifier,omitempty"`
+	Type			   string                 `json:"type"`
+	Data               interface{}            `json:"data,omitempty"`
+	Description        string                 `json:"description,omitempty"`
+	FallbackImage      *FlourishFallbackImage `json:"fallbackImage,omitempty"`
+	FlourishType       string                 `json:"flourishType,omitempty"`
+	Id                 string                 `json:"id,omitempty"`
+	LayoutWidth        string                 `json:"layoutWidth,omitempty"`
+	Timestamp          string                 `json:"timestamp,omitempty"`
+	FragmentIdentifier string                 `json:"fragmentIdentifier,omitempty"`
 }
 
 func (n *Flourish) GetType() string {
@@ -625,11 +625,11 @@ type FlourishFallbackImageSourceSetElem struct {
 }
 
 type Heading struct {
-	Type     string      `json:"type"`
-	Children []*Text     `json:"children,omitempty"`
-	Data     interface{} `json:"data,omitempty"`
-	Level    string      `json:"level,omitempty"`
-	BlockIdentifier string      `json:"blockIdentifier,omitempty"`
+	Type               string      `json:"type"`
+	Children           []*Text     `json:"children,omitempty"`
+	Data               interface{} `json:"data,omitempty"`
+	Level              string      `json:"level,omitempty"`
+	FragmentIdentifier string      `json:"fragmentIdentifier,omitempty"`
 }
 
 func (n *Heading) GetType() string {
@@ -649,11 +649,11 @@ func (n *Heading) GetChildren() []Node {
 }
 
 type ImageSet struct {
-	Type            string      `json:"type"`
-	Data            interface{} `json:"data,omitempty"`
-	ID              string      `json:"id,omitempty"`
-	Picture         *Picture    `json:"picture,omitempty"`
-	BlockIdentifier string      `json:"blockIdentifier,omitempty"`
+	Type               string      `json:"type"`
+	Data               interface{} `json:"data,omitempty"`
+	ID                 string      `json:"id,omitempty"`
+	Picture            *Picture    `json:"picture,omitempty"`
+	FragmentIdentifier string      `json:"fragmentIdentifier,omitempty"`
 }
 
 func (n *ImageSet) GetType() string {

--- a/libraries/from-bodyxml/index.js
+++ b/libraries/from-bodyxml/index.js
@@ -56,44 +56,44 @@ export let defaultTransformers = {
    * @type {Transformer<ContentTree.transit.Heading>}
    */
   h1(h1) {
-    const blockId = h1.attributes["data-fragment-id"] || h1.attributes["id"];
+    const fragmentId = h1.attributes["data-fragment-id"] || h1.attributes["id"];
     return {
       type: "heading",
       level: "chapter",
-      ...(blockId && { blockIdentifier: blockId }),
+      ...(fragmentId && { fragmentIdentifier: fragmentId }),
     };
   },
   /**
    * @type {Transformer<ContentTree.transit.Heading>}
    */
   h2(h2) {
-    const blockId = h2.attributes["data-fragment-id"] || h2.attributes["id"];
+    const fragmentId = h2.attributes["data-fragment-id"] || h2.attributes["id"];
     return {
       type: "heading",
       level: "subheading",
-      ...(blockId && { blockIdentifier: blockId }),
+      ...(fragmentId && { fragmentIdentifier: fragmentId }),
     };
   },
   /**
    * @type {Transformer<ContentTree.transit.Heading>}
    */
   h3(h3) {
-    const blockId = h3.attributes["data-fragment-id"] || h3.attributes["id"];
+    const fragmentId = h3.attributes["data-fragment-id"] || h3.attributes["id"];
     return {
       type: "heading",
       level: "subheading",
-      ...(blockId && { blockIdentifier: blockId }),
+      ...(fragmentId && { fragmentIdentifier: fragmentId }),
     };
   },
   /**
    * @type {Transformer<ContentTree.transit.Heading>}
    */
   h4(h4) {
-    const blockId = h4.attributes["data-fragment-id"] || h4.attributes["id"];
+    const fragmentId = h4.attributes["data-fragment-id"] || h4.attributes["id"];
     return {
       type: "heading",
       level: "label",
-      ...(blockId && { blockIdentifier: blockId }),
+      ...(fragmentId && { fragmentIdentifier: fragmentId }),
     };
   },
   /**
@@ -245,11 +245,11 @@ export let defaultTransformers = {
    * @type {Transformer<ContentTree.transit.ImageSet>}
    */
   [ContentType.imageset](content) {
-    const blockId = content.attributes["data-fragment-id"] || content.attributes["id"];
+    const fragmentId = content.attributes["data-fragment-id"] || content.attributes["id"];
     return {
       type: "image-set",
       id: content.attributes.url ?? "",
-      ...(blockId && { blockIdentifier: blockId }),
+      ...(fragmentId && { fragmentIdentifier: fragmentId }),
       children: null,
     };
   },
@@ -270,7 +270,7 @@ export let defaultTransformers = {
   [ContentType.content](content) {
     const id = content.attributes.url ?? "";
     const uuid = id.split("/").pop();
-    const blockId = content.attributes["data-fragment-id"] || content.attributes["id"];
+    const fragmentId = content.attributes["data-fragment-id"] || content.attributes["id"];
 
     if (content.attributes["data-asset-type"] == "flourish") {
       return /** @type {ContentTree.transit.Flourish} */ ({
@@ -282,7 +282,7 @@ export let defaultTransformers = {
         ),
         description: content.attributes["alt"] || "",
         timestamp: content.attributes["data-time-stamp"] || "",
-        ...(blockId && { blockIdentifier: blockId }),
+        ...(fragmentId && { fragmentIdentifier: fragmentId }),
         children: null,
       });
     }

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -188,14 +188,14 @@
         "ContentTree.transit.Flourish": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
-                    "type": "string"
-                },
                 "data": {},
                 "description": {
                     "type": "string"
                 },
                 "flourishType": {
+                    "type": "string"
+                },
+                "fragmentIdentifier": {
                     "type": "string"
                 },
                 "id": {
@@ -223,9 +223,6 @@
         "ContentTree.transit.Heading": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
-                    "type": "string"
-                },
                 "children": {
                     "items": {
                         "$ref": "#/definitions/ContentTree.transit.Text"
@@ -233,6 +230,9 @@
                     "type": "array"
                 },
                 "data": {},
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "level": {
                     "enum": [
                         "chapter",
@@ -256,10 +256,10 @@
         "ContentTree.transit.ImageSet": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
+                "data": {},
+                "fragmentIdentifier": {
                     "type": "string"
                 },
-                "data": {},
                 "id": {
                     "type": "string"
                 },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -239,9 +239,6 @@
         "ContentTree.full.Flourish": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
-                    "type": "string"
-                },
                 "data": {},
                 "description": {
                     "type": "string"
@@ -309,6 +306,9 @@
                 "flourishType": {
                     "type": "string"
                 },
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -334,9 +334,6 @@
         "ContentTree.full.Heading": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
-                    "type": "string"
-                },
                 "children": {
                     "items": {
                         "$ref": "#/definitions/ContentTree.full.Text"
@@ -344,6 +341,9 @@
                     "type": "array"
                 },
                 "data": {},
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "level": {
                     "enum": [
                         "chapter",
@@ -367,10 +367,10 @@
         "ContentTree.full.ImageSet": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
+                "data": {},
+                "fragmentIdentifier": {
                     "type": "string"
                 },
-                "data": {},
                 "id": {
                     "type": "string"
                 },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -213,14 +213,14 @@
         "ContentTree.transit.Flourish": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
-                    "type": "string"
-                },
                 "data": {},
                 "description": {
                     "type": "string"
                 },
                 "flourishType": {
+                    "type": "string"
+                },
+                "fragmentIdentifier": {
                     "type": "string"
                 },
                 "id": {
@@ -248,9 +248,6 @@
         "ContentTree.transit.Heading": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
-                    "type": "string"
-                },
                 "children": {
                     "items": {
                         "$ref": "#/definitions/ContentTree.transit.Text"
@@ -258,6 +255,9 @@
                     "type": "array"
                 },
                 "data": {},
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "level": {
                     "enum": [
                         "chapter",
@@ -281,10 +281,10 @@
         "ContentTree.transit.ImageSet": {
             "additionalProperties": false,
             "properties": {
-                "blockIdentifier": {
+                "data": {},
+                "fragmentIdentifier": {
                     "type": "string"
                 },
-                "data": {},
                 "id": {
                     "type": "string"
                 },


### PR DESCRIPTION
We recently added **[blockIdentifier](https://github.com/Financial-Times/content-tree/pull/103)** to the Content Tree. This PR renames it to `fragmentIdentifier` to better align with the terminology used in Spark.