### PR TITLE
feat: add timeline and event nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ type BodyBlock =
 	| Video
 	| YoutubeVideo
 	| Text
+	| Timeline
 	| ImagePair
 ```
 
@@ -762,24 +763,24 @@ interface Table extends Parent {
 
 ```ts
 type CustomCodeComponentAttributes = {
-    [key: string]: string | boolean | undefined
+	[key: string]: string | boolean | undefined
 }
 
 interface CustomCodeComponent extends Node {
-  /** Component type */
-  type: "custom-code-component"
-  /** Id taken from the CAPI url */
-  id: string
-  /** How the component should be presented in the article page according to the column layout system */
-  layoutWidth: LayoutWidth
-  /** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
-  external path: string
-  /** Semantic version of the code of the component, e.g. "^0.3.5". */
-  external versionRange: string
-  /** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
-  external attributesLastModified: string
-  /** Configuration data to be passed to the component. */
-  external attributes: CustomCodeComponentAttributes
+	/** Component type */
+	type: "custom-code-component"
+	/** Id taken from the CAPI url */
+	id: string
+	/** How the component should be presented in the article page according to the column layout system */
+	layoutWidth: LayoutWidth
+	/** Repository for the code of the component in the format "[github org]/[github repo]/[component name]". */
+	external path: string
+	/** Semantic version of the code of the component, e.g. "^0.3.5". */
+	external versionRange: string
+	/** Last date-time when the attributes for this block were modified, in ISO-8601 format. */
+	external attributesLastModified: string
+	/** Configuration data to be passed to the component. */
+	external attributes: CustomCodeComponentAttributes
 }
 ```
 
@@ -798,6 +799,31 @@ interface ImagePair extends Parent {
 ```
 
 **ImagePair** is a set of two images
+
+### Timeline
+
+```ts
+/**
+ * Timeline nodes display a timeline of events in arbitrary order.
+ */
+interface Timeline extends Parent {
+	type: "timeline"
+	/** The title for the timeline */
+	title: string
+	children: TimelineEvent[]
+}
+
+/**
+ * TimelineEvent is the representation of a single event in a Timeline.
+ */
+interface TimelineEvent extends Parent {
+	type: "timeline-event"
+	/** The title of the event */
+	title: string
+	/** Any combination of paragraphs and image sets */
+	children: (Paragraph | ImageSet)[];
+}
+```
 
 ## License
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -1,5 +1,5 @@
 export declare namespace ContentTree {
-    type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | ImagePair;
+    type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
     type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
     type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
     interface Node {
@@ -289,8 +289,27 @@ export declare namespace ContentTree {
         type: 'image-pair';
         children: [ImageSet, ImageSet];
     }
+    /**
+     * Timeline nodes display a timeline of events in arbitrary order.
+     */
+    interface Timeline extends Parent {
+        type: "timeline";
+        /** The title for the timeline */
+        title: string;
+        children: TimelineEvent[];
+    }
+    /**
+     * TimelineEvent is the representation of a single event in a Timeline.
+     */
+    interface TimelineEvent extends Parent {
+        type: "timeline-event";
+        /** The title of the event */
+        title: string;
+        /** Any combination of paragraphs and image sets */
+        children: (Paragraph | ImageSet)[];
+    }
     namespace full {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | ImagePair;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -580,9 +599,28 @@ export declare namespace ContentTree {
             type: 'image-pair';
             children: [ImageSet, ImageSet];
         }
+        /**
+         * Timeline nodes display a timeline of events in arbitrary order.
+         */
+        interface Timeline extends Parent {
+            type: "timeline";
+            /** The title for the timeline */
+            title: string;
+            children: TimelineEvent[];
+        }
+        /**
+         * TimelineEvent is the representation of a single event in a Timeline.
+         */
+        interface TimelineEvent extends Parent {
+            type: "timeline-event";
+            /** The title of the event */
+            title: string;
+            /** Any combination of paragraphs and image sets */
+            children: (Paragraph | ImageSet)[];
+        }
     }
     namespace transit {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | ImagePair;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -857,9 +895,28 @@ export declare namespace ContentTree {
             type: 'image-pair';
             children: [ImageSet, ImageSet];
         }
+        /**
+         * Timeline nodes display a timeline of events in arbitrary order.
+         */
+        interface Timeline extends Parent {
+            type: "timeline";
+            /** The title for the timeline */
+            title: string;
+            children: TimelineEvent[];
+        }
+        /**
+         * TimelineEvent is the representation of a single event in a Timeline.
+         */
+        interface TimelineEvent extends Parent {
+            type: "timeline-event";
+            /** The title of the event */
+            title: string;
+            /** Any combination of paragraphs and image sets */
+            children: (Paragraph | ImageSet)[];
+        }
     }
     namespace loose {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | ImagePair;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -1148,6 +1205,25 @@ export declare namespace ContentTree {
         interface ImagePair extends Parent {
             type: 'image-pair';
             children: [ImageSet, ImageSet];
+        }
+        /**
+         * Timeline nodes display a timeline of events in arbitrary order.
+         */
+        interface Timeline extends Parent {
+            type: "timeline";
+            /** The title for the timeline */
+            title: string;
+            children: TimelineEvent[];
+        }
+        /**
+         * TimelineEvent is the representation of a single event in a Timeline.
+         */
+        interface TimelineEvent extends Parent {
+            type: "timeline-event";
+            /** The title of the event */
+            title: string;
+            /** Any combination of paragraphs and image sets */
+            children: (Paragraph | ImageSet)[];
         }
     }
 }

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -127,6 +127,9 @@
                     "$ref": "#/definitions/ContentTree.transit.Text"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.transit.Timeline"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.transit.ImagePair"
                 }
             ]
@@ -1147,6 +1150,68 @@
                 }
             },
             "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Timeline": {
+            "additionalProperties": false,
+            "description": "Timeline nodes display a timeline of events in arbitrary order.",
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.TimelineEvent"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title for the timeline",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "timeline",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.TimelineEvent": {
+            "additionalProperties": false,
+            "description": "TimelineEvent is the representation of a single event in a Timeline.",
+            "properties": {
+                "children": {
+                    "description": "Any combination of paragraphs and image sets",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.Paragraph"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.ImageSet"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title of the event",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "timeline-event",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
                 "type"
             ],
             "type": "object"

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -152,6 +152,9 @@
                     "$ref": "#/definitions/ContentTree.full.Text"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.full.Timeline"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.full.ImagePair"
                 }
             ]
@@ -1928,6 +1931,68 @@
                 }
             },
             "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.Timeline": {
+            "additionalProperties": false,
+            "description": "Timeline nodes display a timeline of events in arbitrary order.",
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.TimelineEvent"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title for the timeline",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "timeline",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.TimelineEvent": {
+            "additionalProperties": false,
+            "description": "TimelineEvent is the representation of a single event in a Timeline.",
+            "properties": {
+                "children": {
+                    "description": "Any combination of paragraphs and image sets",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ContentTree.full.Paragraph"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.full.ImageSet"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title of the event",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "timeline-event",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
                 "type"
             ],
             "type": "object"

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -152,6 +152,9 @@
                     "$ref": "#/definitions/ContentTree.transit.Text"
                 },
                 {
+                    "$ref": "#/definitions/ContentTree.transit.Timeline"
+                },
+                {
                     "$ref": "#/definitions/ContentTree.transit.ImagePair"
                 }
             ]
@@ -1172,6 +1175,68 @@
                 }
             },
             "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Timeline": {
+            "additionalProperties": false,
+            "description": "Timeline nodes display a timeline of events in arbitrary order.",
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.TimelineEvent"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title for the timeline",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "timeline",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.TimelineEvent": {
+            "additionalProperties": false,
+            "description": "TimelineEvent is the representation of a single event in a Timeline.",
+            "properties": {
+                "children": {
+                    "description": "Any combination of paragraphs and image sets",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.Paragraph"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.ImageSet"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title of the event",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "timeline-event",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
                 "type"
             ],
             "type": "object"


### PR DESCRIPTION
Create a timeline and timeline-event nodes so we can move timeline name out of the Layout node. We want to move away from experimental tags that requires to discontinue the usage of Layouts from the bodyXML.
