### PR TITLE
ADSDEV-2383: add support to OnwardJourneyLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ type LayoutWidth =
 ### `Phrasing`
 
 ```ts
-type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link
+type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | OnwardJourneyLink
 ```
 
 A phrasing node cannot have ancestor of the same type.
@@ -298,6 +298,19 @@ interface Link extends Parent {
 ```
 
 **Link** represents a hyperlink.
+
+### `OnwardJourneyLink`
+
+```ts
+interface OnwardJourneyLink extends Parent {
+	type: "onward-journey-link"
+	url: string
+	title: string
+	children: Phrasing[]
+}
+```
+
+**OnwardJourneyLink** represents a hyperlink in a partner content onward journey.
 
 ### `List`
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -1,7 +1,7 @@
 export declare namespace ContentTree {
     type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
     type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
-    type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
+    type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | OnwardJourneyLink;
     interface Node {
         type: string;
         data?: any;
@@ -52,6 +52,12 @@ export declare namespace ContentTree {
     }
     interface Link extends Parent {
         type: "link";
+        url: string;
+        title: string;
+        children: Phrasing[];
+    }
+    interface OnwardJourneyLink extends Parent {
+        type: "onward-journey-link";
         url: string;
         title: string;
         children: Phrasing[];
@@ -281,7 +287,7 @@ export declare namespace ContentTree {
     namespace full {
         type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
-        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
+        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | OnwardJourneyLink;
         interface Node {
             type: string;
             data?: any;
@@ -332,6 +338,12 @@ export declare namespace ContentTree {
         }
         interface Link extends Parent {
             type: "link";
+            url: string;
+            title: string;
+            children: Phrasing[];
+        }
+        interface OnwardJourneyLink extends Parent {
+            type: "onward-journey-link";
             url: string;
             title: string;
             children: Phrasing[];
@@ -562,7 +574,7 @@ export declare namespace ContentTree {
     namespace transit {
         type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
-        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
+        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | OnwardJourneyLink;
         interface Node {
             type: string;
             data?: any;
@@ -613,6 +625,12 @@ export declare namespace ContentTree {
         }
         interface Link extends Parent {
             type: "link";
+            url: string;
+            title: string;
+            children: Phrasing[];
+        }
+        interface OnwardJourneyLink extends Parent {
+            type: "onward-journey-link";
             url: string;
             title: string;
             children: Phrasing[];
@@ -828,7 +846,7 @@ export declare namespace ContentTree {
     namespace loose {
         type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | Tweet | Video | YoutubeVideo | Text;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
-        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
+        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | OnwardJourneyLink;
         interface Node {
             type: string;
             data?: any;
@@ -879,6 +897,12 @@ export declare namespace ContentTree {
         }
         interface Link extends Parent {
             type: "link";
+            url: string;
+            title: string;
+            children: Phrasing[];
+        }
+        interface OnwardJourneyLink extends Parent {
+            type: "onward-journey-link";
             url: string;
             title: string;
             children: Phrasing[];

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -50,6 +50,9 @@
                             },
                             {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.OnwardJourneyLink"
                             }
                         ]
                     },
@@ -500,6 +503,9 @@
                             },
                             {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.OnwardJourneyLink"
                             }
                         ]
                     },
@@ -514,6 +520,35 @@
             "required": [
                 "children",
                 "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.OnwardJourneyLink": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "onward-journey-link",
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
+                "type",
+                "url"
             ],
             "type": "object"
         },
@@ -557,6 +592,9 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.Link"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.OnwardJourneyLink"
                 }
             ]
         },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -50,6 +50,9 @@
                             },
                             {
                                 "$ref": "#/definitions/ContentTree.full.Link"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.full.OnwardJourneyLink"
                             }
                         ]
                     },
@@ -927,6 +930,9 @@
                             },
                             {
                                 "$ref": "#/definitions/ContentTree.full.Link"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.full.OnwardJourneyLink"
                             }
                         ]
                     },
@@ -941,6 +947,35 @@
             "required": [
                 "children",
                 "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.OnwardJourneyLink": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "onward-journey-link",
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
+                "type",
+                "url"
             ],
             "type": "object"
         },
@@ -984,6 +1019,9 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.full.Link"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.full.OnwardJourneyLink"
                 }
             ]
         },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -50,6 +50,9 @@
                             },
                             {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.OnwardJourneyLink"
                             }
                         ]
                     },
@@ -525,6 +528,9 @@
                             },
                             {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.OnwardJourneyLink"
                             }
                         ]
                     },
@@ -539,6 +545,35 @@
             "required": [
                 "children",
                 "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.OnwardJourneyLink": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "onward-journey-link",
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "title",
+                "type",
+                "url"
             ],
             "type": "object"
         },
@@ -582,6 +617,9 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.Link"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.OnwardJourneyLink"
                 }
             ]
         },


### PR DESCRIPTION
## Description 

Anchor tags can include the `data-anchor-style` attribute to identify an onward journey link that appears exclusively on partner content articles. As we don't expect this variation to appear in standard articles, we've implemented it as a separate component within the content tree