### PR TITLE
InNumbers component interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ type BodyBlock =
 	| Text
 	| Timeline
 	| ImagePair
+	| InNumbers
+	| Definition
 ```
 
 `BodyBlock` nodes are the only things that are valid as the top level of a `Body`.
@@ -822,6 +824,29 @@ interface TimelineEvent extends Parent {
 	title: string
 	/** Any combination of paragraphs and image sets */
 	children: (Paragraph | ImageSet)[];
+}
+```
+
+### InNumbers
+
+```ts
+/**
+ * A definition has a term and a related description. It is used to describe a term.
+ */
+interface Definition extends Node {
+	type: "definition"
+	term: string
+	description: string
+}
+
+/**
+ * InNumbers represents a set of numbers with related descriptions.
+ */
+interface InNumbers extends Parent {
+	type: "in-numbers"
+	/** The title for the InNumbers */
+	title?: string
+	children: [Definition, Definition, Definition]
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -1,5 +1,5 @@
 export declare namespace ContentTree {
-    type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
+    type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair | InNumbers | Definition;
     type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
     type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
     interface Node {
@@ -308,8 +308,25 @@ export declare namespace ContentTree {
         /** Any combination of paragraphs and image sets */
         children: (Paragraph | ImageSet)[];
     }
+    /**
+     * A definition has a term and a related description. It is used to describe a term.
+     */
+    interface Definition extends Node {
+        type: "definition";
+        term: string;
+        description: string;
+    }
+    /**
+     * InNumbers represents a set of numbers with related descriptions.
+     */
+    interface InNumbers extends Parent {
+        type: "in-numbers";
+        /** The title for the InNumbers */
+        title?: string;
+        children: [Definition, Definition, Definition];
+    }
     namespace full {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair | InNumbers | Definition;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -618,9 +635,26 @@ export declare namespace ContentTree {
             /** Any combination of paragraphs and image sets */
             children: (Paragraph | ImageSet)[];
         }
+        /**
+         * A definition has a term and a related description. It is used to describe a term.
+         */
+        interface Definition extends Node {
+            type: "definition";
+            term: string;
+            description: string;
+        }
+        /**
+         * InNumbers represents a set of numbers with related descriptions.
+         */
+        interface InNumbers extends Parent {
+            type: "in-numbers";
+            /** The title for the InNumbers */
+            title?: string;
+            children: [Definition, Definition, Definition];
+        }
     }
     namespace transit {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair | InNumbers | Definition;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -914,9 +948,26 @@ export declare namespace ContentTree {
             /** Any combination of paragraphs and image sets */
             children: (Paragraph | ImageSet)[];
         }
+        /**
+         * A definition has a term and a related description. It is used to describe a term.
+         */
+        interface Definition extends Node {
+            type: "definition";
+            term: string;
+            description: string;
+        }
+        /**
+         * InNumbers represents a set of numbers with related descriptions.
+         */
+        interface InNumbers extends Parent {
+            type: "in-numbers";
+            /** The title for the InNumbers */
+            title?: string;
+            children: [Definition, Definition, Definition];
+        }
     }
     namespace loose {
-        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair;
+        type BodyBlock = Paragraph | Heading | ImageSet | Flourish | BigNumber | CustomCodeComponent | Layout | List | Blockquote | Pullquote | ScrollyBlock | ThematicBreak | Table | Recommended | RecommendedList | Tweet | Video | YoutubeVideo | Text | Timeline | ImagePair | InNumbers | Definition;
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link;
         interface Node {
@@ -1224,6 +1275,23 @@ export declare namespace ContentTree {
             title: string;
             /** Any combination of paragraphs and image sets */
             children: (Paragraph | ImageSet)[];
+        }
+        /**
+         * A definition has a term and a related description. It is used to describe a term.
+         */
+        interface Definition extends Node {
+            type: "definition";
+            term: string;
+            description: string;
+        }
+        /**
+         * InNumbers represents a set of numbers with related descriptions.
+         */
+        interface InNumbers extends Parent {
+            type: "in-numbers";
+            /** The title for the InNumbers */
+            title?: string;
+            children: [Definition, Definition, Definition];
         }
     }
 }

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -131,6 +131,12 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.ImagePair"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.InNumbers"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.Definition"
                 }
             ]
         },
@@ -169,6 +175,29 @@
             "required": [
                 "id",
                 "layoutWidth",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Definition": {
+            "additionalProperties": false,
+            "description": "A definition has a term and a related description. It is used to describe a term.",
+            "properties": {
+                "data": {},
+                "description": {
+                    "type": "string"
+                },
+                "term": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "definition",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "description",
+                "term",
                 "type"
             ],
             "type": "object"
@@ -314,6 +343,42 @@
             },
             "required": [
                 "id",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.InNumbers": {
+            "additionalProperties": false,
+            "description": "InNumbers represents a set of numbers with related descriptions.",
+            "properties": {
+                "children": {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.Definition"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.Definition"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.Definition"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title for the InNumbers",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "in-numbers",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
                 "type"
             ],
             "type": "object"

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -156,6 +156,12 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.full.ImagePair"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.full.InNumbers"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.full.Definition"
                 }
             ]
         },
@@ -221,6 +227,29 @@
                 "path",
                 "type",
                 "versionRange"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.Definition": {
+            "additionalProperties": false,
+            "description": "A definition has a term and a related description. It is used to describe a term.",
+            "properties": {
+                "data": {},
+                "description": {
+                    "type": "string"
+                },
+                "term": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "definition",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "description",
+                "term",
+                "type"
             ],
             "type": "object"
         },
@@ -583,6 +612,42 @@
             "required": [
                 "id",
                 "picture",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.InNumbers": {
+            "additionalProperties": false,
+            "description": "InNumbers represents a set of numbers with related descriptions.",
+            "properties": {
+                "children": {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.full.Definition"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.Definition"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.full.Definition"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title for the InNumbers",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "in-numbers",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
                 "type"
             ],
             "type": "object"

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -156,6 +156,12 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.ImagePair"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.InNumbers"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.Definition"
                 }
             ]
         },
@@ -194,6 +200,29 @@
             "required": [
                 "id",
                 "layoutWidth",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Definition": {
+            "additionalProperties": false,
+            "description": "A definition has a term and a related description. It is used to describe a term.",
+            "properties": {
+                "data": {},
+                "description": {
+                    "type": "string"
+                },
+                "term": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "definition",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "description",
+                "term",
                 "type"
             ],
             "type": "object"
@@ -339,6 +368,42 @@
             },
             "required": [
                 "id",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.InNumbers": {
+            "additionalProperties": false,
+            "description": "InNumbers represents a set of numbers with related descriptions.",
+            "properties": {
+                "children": {
+                    "items": [
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.Definition"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.Definition"
+                        },
+                        {
+                            "$ref": "#/definitions/ContentTree.transit.Definition"
+                        }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "type": "array"
+                },
+                "data": {},
+                "title": {
+                    "description": "The title for the InNumbers",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "in-numbers",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
                 "type"
             ],
             "type": "object"


### PR DESCRIPTION
Representation for an `In numbers` component 

<img width="842" height="193" alt="image" src="https://github.com/user-attachments/assets/a1b2f3f5-88a5-4c03-9e39-0ae01bac359a" />

This is related to the issue about [moving away from the Layout component](https://github.com/Financial-Times/content-tree/issues/106)