### PR TITLE
ADSDEV-2383: add styleType attribute to Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ interface Link extends Parent {
 	url: string
 	title: string
 	children: Phrasing[]
+	styleType?: 'onward-journey'
 }
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -55,6 +55,7 @@ export declare namespace ContentTree {
         url: string;
         title: string;
         children: Phrasing[];
+        styleType?: 'onward-journey';
     }
     interface List extends Parent {
         type: "list";
@@ -335,6 +336,7 @@ export declare namespace ContentTree {
             url: string;
             title: string;
             children: Phrasing[];
+            styleType?: 'onward-journey';
         }
         interface List extends Parent {
             type: "list";
@@ -616,6 +618,7 @@ export declare namespace ContentTree {
             url: string;
             title: string;
             children: Phrasing[];
+            styleType?: 'onward-journey';
         }
         interface List extends Parent {
             type: "list";
@@ -882,6 +885,7 @@ export declare namespace ContentTree {
             url: string;
             title: string;
             children: Phrasing[];
+            styleType?: 'onward-journey';
         }
         interface List extends Parent {
             type: "list";

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -430,6 +430,10 @@
                     "type": "array"
                 },
                 "data": {},
+                "styleType": {
+                    "const": "onward-journey",
+                    "type": "string"
+                },
                 "title": {
                     "type": "string"
                 },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -857,6 +857,10 @@
                     "type": "array"
                 },
                 "data": {},
+                "styleType": {
+                    "const": "onward-journey",
+                    "type": "string"
+                },
                 "title": {
                     "type": "string"
                 },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -455,6 +455,10 @@
                     "type": "array"
                 },
                 "data": {},
+                "styleType": {
+                    "const": "onward-journey",
+                    "type": "string"
+                },
                 "title": {
                     "type": "string"
                 },


### PR DESCRIPTION
# Description

Anchor tags can include the `data-anchor-style` attribute to identify style variations from the standard link. It was introduced to differentiate the Partner Content onward journey link from the standard link.