### PR TITLE
add timeline section to content-tree Go representation

### DIFF
--- a/libraries/to-external-bodyxml/go/transform.go
+++ b/libraries/to-external-bodyxml/go/transform.go
@@ -255,7 +255,29 @@ func transformNode(n contenttree.Node) (string, error) {
 	// CCC nodes won't be available in the "external" body XML format.
 	case *contenttree.CustomCodeComponent:
 		return "", nil
-
+	/*
+		TODO: Remove comment to integrate timeline.
+		case *contenttree.Timeline:
+			{
+				titleXML := ""
+				if node.Title != "" {
+					titleXML = fmt.Sprintf("<h3>%s</h3>", node.Title)
+				}
+				layoutWidthXML := ""
+				if node.LayoutWidth != "" {
+					layoutWidthXML = fmt.Sprintf("data-layout-width=\"%s\"", node.LayoutWidth)
+				}
+				return fmt.Sprintf("<section data-type=\"timeline\" %s>%s<ol data-type=\"timeline_events\">%s</ol></section>", layoutWidthXML, titleXML, innerXML), nil
+			}
+		case *contenttree.TimelineEvent:
+			{
+				titleXML := ""
+				if node.Title != "" {
+					titleXML = fmt.Sprintf("<h4>%s</h4>", node.Title)
+				}
+				return fmt.Sprintf("<li data-type=\"timeline_event\">%s%s</li>", titleXML, innerXML), nil
+			}
+	*/
 	// content tree nodes which require transformation of their embedded nodes
 	case *contenttree.BodyBlock:
 		return transformNode(n.GetEmbedded())
@@ -275,6 +297,11 @@ func transformNode(n contenttree.Node) (string, error) {
 		return transformNode(n.GetEmbedded())
 	case *contenttree.TableChild:
 		return transformNode(n.GetEmbedded())
+		/*
+			TODO: Remove comment to integrate timeline.
+			case *contenttree.TimelineEventChild:
+				return transformNode(n.GetEmbedded())
+		*/
 	}
 
 	return "", nil

--- a/tests/bodyxml-to-content-tree/input/simple-body-section.xml
+++ b/tests/bodyxml-to-content-tree/input/simple-body-section.xml
@@ -1,0 +1,1 @@
+<body><section data-type="timeline" data-layout-width="full-width"><h3>lorem</h3><ol data-type="timeline_events"><li data-type="timeline_event"><h4>ipsum</h4><p>lorem</p><p>ipsum</p><content type="http://www.ft.com/ontology/content/ImageSet" id="a47cfe4c-1f80-4492-9717-93aa65565e37"/></li><li data-type="timeline_event"><h4>lorem</h4><p>ipsum</p></li></ol></section></body>

--- a/tests/bodyxml-to-content-tree/output/simple-body-section.json
+++ b/tests/bodyxml-to-content-tree/output/simple-body-section.json
@@ -1,0 +1,59 @@
+{
+  "type": "root",
+  "body": {
+    "type": "body",
+    "children": [
+      {
+        "type": "timeline",
+        "title": "lorem",
+        "layoutWidth": "full-width",
+        "children": [
+          {
+            "type": "timeline-event",
+            "title": "ipsum",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "lorem"
+                  }
+                ]
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "ipsum"
+                  }
+                ]
+              },
+              {
+                "type": "image-set",
+                "id": "a47cfe4c-1f80-4492-9717-93aa65565e37"
+              }
+            ]
+          },
+          {
+            "type": "timeline-event",
+            "title": "lorem",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "ipsum"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "version": 1
+  }
+}


### PR DESCRIPTION
This PR introduces the timeline section to the Go representation of the content-tree.
The bodyXML-to-content-tree Go transformer has been updated to support this new element.

- The transformer expects the following structure:
- The data-type attribute must have the value timeline when representing a timeline element.
- The ol element must have the data-type attribute set to timeline_events.
- Each li element within the list must have the data-type attribute set to timeline_event.

JIRA --> https://financialtimes.atlassian.net/browse/UPPSF-6510