### PR TITLE
ADSDEV-2383: Remove title property from find-out-more-link

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -277,7 +277,6 @@ interface Link extends Parent {
 interface FindOutMoreLink extends Parent {
 	type: "find-out-more-link"
 	url: string
-	title: string
 	children: [Text | Strong | Emphasis]
 }
 ```

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -72,7 +72,6 @@ export declare namespace ContentTree {
     interface FindOutMoreLink extends Parent {
         type: "find-out-more-link";
         url: string;
-        title: string;
         children: [Text | Strong | Emphasis];
     }
     interface List extends Parent {
@@ -496,7 +495,6 @@ export declare namespace ContentTree {
         interface FindOutMoreLink extends Parent {
             type: "find-out-more-link";
             url: string;
-            title: string;
             children: [Text | Strong | Emphasis];
         }
         interface List extends Parent {
@@ -921,7 +919,6 @@ export declare namespace ContentTree {
         interface FindOutMoreLink extends Parent {
             type: "find-out-more-link";
             url: string;
-            title: string;
             children: [Text | Strong | Emphasis];
         }
         interface List extends Parent {
@@ -1319,7 +1316,6 @@ export declare namespace ContentTree {
         interface FindOutMoreLink extends Parent {
             type: "find-out-more-link";
             url: string;
-            title: string;
             children: [Text | Strong | Emphasis];
         }
         interface List extends Parent {

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -353,9 +353,6 @@
                     "type": "array"
                 },
                 "data": {},
-                "title": {
-                    "type": "string"
-                },
                 "type": {
                     "const": "find-out-more-link",
                     "type": "string"
@@ -366,7 +363,6 @@
             },
             "required": [
                 "children",
-                "title",
                 "type",
                 "url"
             ],

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -506,9 +506,6 @@
                     "type": "array"
                 },
                 "data": {},
-                "title": {
-                    "type": "string"
-                },
                 "type": {
                     "const": "find-out-more-link",
                     "type": "string"
@@ -519,7 +516,6 @@
             },
             "required": [
                 "children",
-                "title",
                 "type",
                 "url"
             ],

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -378,9 +378,6 @@
                     "type": "array"
                 },
                 "data": {},
-                "title": {
-                    "type": "string"
-                },
                 "type": {
                     "const": "find-out-more-link",
                     "type": "string"
@@ -391,7 +388,6 @@
             },
             "required": [
                 "children",
-                "title",
                 "type",
                 "url"
             ],


### PR DESCRIPTION
## Description

This attribute is not currently supported by the component.
We're removing to avoid confusion on the component implementation