### PR TITLE
Bump package version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@financial-times/content-tree",
 	"description": "content tree format",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"publishConfig": {
 		"access": "public"
   },


### PR DESCRIPTION
## Description

This version includes the changes to remove the `title` attribute from `FindOutMoreLink` component

PRs:

- https://github.com/Financial-Times/content-tree/pull/156
- https://github.com/Financial-Times/content-tree/pull/158