### PR TITLE
Add support for superscript/subscript

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -163,7 +163,7 @@ interface Text extends Node {
 ### `Phrasing`
 
 ```ts
-type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | FindOutMoreLink
+type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Subscript | Superscript | Link | FindOutMoreLink
 ```
 
 A phrasing node cannot have ancestor of the same type.
@@ -256,6 +256,28 @@ interface Strikethrough extends Parent {
 ```
 
 **Strikethrough** represents a piece of text that has been stricken.
+
+### Subscript 
+
+```ts
+interface Subscript extends Parent {
+	type: "subscript"
+	children: Phrasing[]
+}
+```
+
+**Subscript** represents a piece of text that has a lowered baseline.
+
+### Superscript 
+
+```ts
+interface Superscript extends Parent {
+	type: "superscript"
+	children: Phrasing[]
+}
+```
+
+**Superscript** represents a piece of text with a raised baseline.
 
 ### `Link`
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -34,7 +34,7 @@ export declare namespace ContentTree {
         type: "text";
         value: string;
     }
-    type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | FindOutMoreLink;
+    type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Subscript | Superscript | Link | FindOutMoreLink;
     interface Break extends Node {
         type: "break";
     }
@@ -61,6 +61,14 @@ export declare namespace ContentTree {
     }
     interface Strikethrough extends Parent {
         type: "strikethrough";
+        children: Phrasing[];
+    }
+    interface Subscript extends Parent {
+        type: "subscript";
+        children: Phrasing[];
+    }
+    interface Superscript extends Parent {
+        type: "superscript";
         children: Phrasing[];
     }
     interface Link extends Parent {
@@ -462,7 +470,7 @@ export declare namespace ContentTree {
             type: "text";
             value: string;
         }
-        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | FindOutMoreLink;
+        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Subscript | Superscript | Link | FindOutMoreLink;
         interface Break extends Node {
             type: "break";
         }
@@ -489,6 +497,14 @@ export declare namespace ContentTree {
         }
         interface Strikethrough extends Parent {
             type: "strikethrough";
+            children: Phrasing[];
+        }
+        interface Subscript extends Parent {
+            type: "subscript";
+            children: Phrasing[];
+        }
+        interface Superscript extends Parent {
+            type: "superscript";
             children: Phrasing[];
         }
         interface Link extends Parent {
@@ -891,7 +907,7 @@ export declare namespace ContentTree {
             type: "text";
             value: string;
         }
-        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | FindOutMoreLink;
+        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Subscript | Superscript | Link | FindOutMoreLink;
         interface Break extends Node {
             type: "break";
         }
@@ -918,6 +934,14 @@ export declare namespace ContentTree {
         }
         interface Strikethrough extends Parent {
             type: "strikethrough";
+            children: Phrasing[];
+        }
+        interface Subscript extends Parent {
+            type: "subscript";
+            children: Phrasing[];
+        }
+        interface Superscript extends Parent {
+            type: "superscript";
             children: Phrasing[];
         }
         interface Link extends Parent {
@@ -1293,7 +1317,7 @@ export declare namespace ContentTree {
             type: "text";
             value: string;
         }
-        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Link | FindOutMoreLink;
+        type Phrasing = Text | Break | Strong | Emphasis | Strikethrough | Subscript | Superscript | Link | FindOutMoreLink;
         interface Break extends Node {
             type: "break";
         }
@@ -1320,6 +1344,14 @@ export declare namespace ContentTree {
         }
         interface Strikethrough extends Parent {
             type: "strikethrough";
+            children: Phrasing[];
+        }
+        interface Subscript extends Parent {
+            type: "subscript";
+            children: Phrasing[];
+        }
+        interface Superscript extends Parent {
+            type: "superscript";
             children: Phrasing[];
         }
         interface Link extends Parent {

--- a/content_tree.go
+++ b/content_tree.go
@@ -38,6 +38,8 @@ const (
 	StrongType               = "strong"
 	EmphasisType             = "emphasis"
 	StrikethroughType        = "strikethrough"
+	SubscriptType            = "subscript"
+	SuperscriptType          = "superscript"
 	LinkType                 = "link"
 	FindOutMoreLinkType      = "find-out-more-link"
 	FindOutMoreLinkChildType = "find-out-more-link-child"
@@ -201,6 +203,8 @@ type BlockquoteChild struct {
 	*Strong
 	*Emphasis
 	*Strikethrough
+	*Subscript
+	*Superscript
 	*Link
 	*FindOutMoreLink
 }
@@ -227,6 +231,12 @@ func (n *BlockquoteChild) GetEmbedded() Node {
 	}
 	if n.Strikethrough != nil {
 		return n.Strikethrough
+	}
+	if n.Subscript != nil {
+		return n.Subscript
+	}
+	if n.Superscript != nil {
+		return n.Superscript
 	}
 	if n.Link != nil {
 		return n.Link
@@ -255,6 +265,12 @@ func (n *BlockquoteChild) GetChildren() []Node {
 	}
 	if n.Strikethrough != nil {
 		return n.Strikethrough.GetChildren()
+	}
+	if n.Subscript != nil {
+		return n.Subscript.GetChildren()
+	}
+	if n.Superscript != nil {
+		return n.Superscript.GetChildren()
 	}
 	if n.Link != nil {
 		return n.Link.GetChildren()
@@ -310,6 +326,18 @@ func (n *BlockquoteChild) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		n.Strikethrough = &v
+	case SubscriptType:
+		var v Subscript
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		n.Subscript = &v
+	case SuperscriptType:
+		var v Superscript
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		n.Superscript = &v
 	case LinkType:
 		var v Link
 		if err := json.Unmarshal(data, &v); err != nil {
@@ -342,6 +370,10 @@ func (n *BlockquoteChild) MarshalJSON() ([]byte, error) {
 		return json.Marshal(n.Emphasis)
 	case n.Strikethrough != nil:
 		return json.Marshal(n.Strikethrough)
+	case n.Subscript != nil:
+		return json.Marshal(n.Subscript)
+	case n.Superscript != nil:
+		return json.Marshal(n.Superscript)
 	case n.Link != nil:
 		return json.Marshal(n.Link)
 	case n.FindOutMoreLink != nil:
@@ -366,6 +398,10 @@ func makeBlockquoteChild(n Node) (*BlockquoteChild, error) {
 		return &BlockquoteChild{Emphasis: n.(*Emphasis)}, nil
 	case StrikethroughType:
 		return &BlockquoteChild{Strikethrough: n.(*Strikethrough)}, nil
+	case SubscriptType:
+		return &BlockquoteChild{Subscript: n.(*Subscript)}, nil
+	case SuperscriptType:
+		return &BlockquoteChild{Superscript: n.(*Superscript)}, nil
 	case LinkType:
 		return &BlockquoteChild{Link: n.(*Link)}, nil
 	case FindOutMoreLinkType:
@@ -1557,6 +1593,8 @@ type ListItemChild struct {
 	*Strong
 	*Emphasis
 	*Strikethrough
+	*Subscript
+	*Superscript
 	*Link
 	*FindOutMoreLink
 }
@@ -1583,6 +1621,12 @@ func (n *ListItemChild) GetEmbedded() Node {
 	}
 	if n.Strikethrough != nil {
 		return n.Strikethrough
+	}
+	if n.Subscript != nil {
+		return n.Subscript
+	}
+	if n.Superscript != nil {
+		return n.Superscript
 	}
 	if n.Link != nil {
 		return n.Link
@@ -1611,6 +1655,12 @@ func (n *ListItemChild) GetChildren() []Node {
 	}
 	if n.Strikethrough != nil {
 		return n.Strikethrough.GetChildren()
+	}
+	if n.Subscript != nil {
+		return n.Subscript.GetChildren()
+	}
+	if n.Superscript != nil {
+		return n.Superscript.GetChildren()
 	}
 	if n.Link != nil {
 		return n.Link.GetChildren()
@@ -1669,6 +1719,18 @@ func (n *ListItemChild) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		n.Strikethrough = &v
+	case SubscriptType:
+		var v Subscript
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		n.Subscript = &v
+	case SuperscriptType:
+		var v Superscript
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		n.Superscript = &v
 	case LinkType:
 		var v Link
 		if err := json.Unmarshal(data, &v); err != nil {
@@ -1701,6 +1763,10 @@ func (n *ListItemChild) MarshalJSON() ([]byte, error) {
 		return json.Marshal(n.Emphasis)
 	case n.Strikethrough != nil:
 		return json.Marshal(n.Strikethrough)
+	case n.Subscript != nil:
+		return json.Marshal(n.Subscript)
+	case n.Superscript != nil:
+		return json.Marshal(n.Superscript)
 	case n.Link != nil:
 		return json.Marshal(n.Link)
 	case n.FindOutMoreLink != nil:
@@ -1725,6 +1791,10 @@ func makeListItemChild(n Node) (*ListItemChild, error) {
 		return &ListItemChild{Emphasis: n.(*Emphasis)}, nil
 	case StrikethroughType:
 		return &ListItemChild{Strikethrough: n.(*Strikethrough)}, nil
+	case SubscriptType:
+		return &ListItemChild{Subscript: n.(*Subscript)}, nil
+	case SuperscriptType:
+		return &ListItemChild{Superscript: n.(*Superscript)}, nil
 	case LinkType:
 		return &ListItemChild{Link: n.(*Link)}, nil
 	case FindOutMoreLinkType:
@@ -1770,6 +1840,8 @@ type Phrasing struct {
 	*Strong
 	*Emphasis
 	*Strikethrough
+	*Subscript
+	*Superscript
 	*Link
 	*FindOutMoreLink
 }
@@ -1793,6 +1865,12 @@ func (n *Phrasing) GetEmbedded() Node {
 	}
 	if n.Strikethrough != nil {
 		return n.Strikethrough
+	}
+	if n.Subscript != nil {
+		return n.Subscript
+	}
+	if n.Superscript != nil {
+		return n.Superscript
 	}
 	if n.Link != nil {
 		return n.Link
@@ -1818,6 +1896,12 @@ func (n *Phrasing) GetChildren() []Node {
 	}
 	if n.Strikethrough != nil {
 		return n.Strikethrough.GetChildren()
+	}
+	if n.Subscript != nil {
+		return n.Subscript.GetChildren()
+	}
+	if n.Superscript != nil {
+		return n.Superscript.GetChildren()
 	}
 	if n.Link != nil {
 		return n.Link.GetChildren()
@@ -1867,6 +1951,18 @@ func (n *Phrasing) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		n.Strikethrough = &v
+	case SubscriptType:
+		var v Subscript
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		n.Subscript = &v
+	case SuperscriptType:
+		var v Superscript
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		n.Superscript = &v
 	case LinkType:
 		var v Link
 		if err := json.Unmarshal(data, &v); err != nil {
@@ -1897,6 +1993,10 @@ func (n *Phrasing) MarshalJSON() ([]byte, error) {
 		return json.Marshal(n.Emphasis)
 	case n.Strikethrough != nil:
 		return json.Marshal(n.Strikethrough)
+	case n.Subscript != nil:
+		return json.Marshal(n.Subscript)
+	case n.Superscript != nil:
+		return json.Marshal(n.Superscript)
 	case n.Link != nil:
 		return json.Marshal(n.Link)
 	case n.FindOutMoreLink != nil:
@@ -1919,6 +2019,10 @@ func makePhrasing(n Node) (*Phrasing, error) {
 		return &Phrasing{Emphasis: n.(*Emphasis)}, nil
 	case StrikethroughType:
 		return &Phrasing{Strikethrough: n.(*Strikethrough)}, nil
+	case SubscriptType:
+		return &Phrasing{Subscript: n.(*Subscript)}, nil
+	case SuperscriptType:
+		return &Phrasing{Superscript: n.(*Superscript)}, nil
 	case LinkType:
 		return &Phrasing{Link: n.(*Link)}, nil
 	case FindOutMoreLinkType:
@@ -2318,6 +2422,66 @@ func (n *Strikethrough) GetChildren() []Node {
 }
 
 func (n *Strikethrough) AppendChild(child Node) error {
+	p, err := makePhrasing(child)
+	if err != nil {
+		return err
+	}
+	n.Children = append(n.Children, p)
+	return nil
+}
+
+type Subscript struct {
+	Type     string      `json:"type"`
+	Children []*Phrasing `json:"children"`
+}
+
+func (n *Subscript) GetType() string {
+	return n.Type
+}
+
+func (n *Subscript) GetEmbedded() Node {
+	return nil
+}
+
+func (n *Subscript) GetChildren() []Node {
+	result := make([]Node, len(n.Children))
+	for i, v := range n.Children {
+		result[i] = v
+	}
+	return result
+}
+
+func (n *Subscript) AppendChild(child Node) error {
+	p, err := makePhrasing(child)
+	if err != nil {
+		return err
+	}
+	n.Children = append(n.Children, p)
+	return nil
+}
+
+type Superscript struct {
+	Type     string      `json:"type"`
+	Children []*Phrasing `json:"children"`
+}
+
+func (n *Superscript) GetType() string {
+	return n.Type
+}
+
+func (n *Superscript) GetEmbedded() Node {
+	return nil
+}
+
+func (n *Superscript) GetChildren() []Node {
+	result := make([]Node, len(n.Children))
+	for i, v := range n.Children {
+		result[i] = v
+	}
+	return result
+}
+
+func (n *Superscript) AppendChild(child Node) error {
 	p, err := makePhrasing(child)
 	if err != nil {
 		return err

--- a/libraries/from-bodyxml/go/html_transformers.go
+++ b/libraries/from-bodyxml/go/html_transformers.go
@@ -136,6 +136,18 @@ var defaultTransformers = map[string]transformer{
 			Children: []*contenttree.Phrasing{},
 		}
 	},
+	"sup": func(_ *etree.Element) contenttree.Node {
+		return &contenttree.Superscript{
+			Type:     contenttree.SuperscriptType,
+			Children: []*contenttree.Phrasing{},
+		}
+	},
+	"sub": func(_ *etree.Element) contenttree.Node {
+		return &contenttree.Subscript{
+			Type:     contenttree.SubscriptType,
+			Children: []*contenttree.Phrasing{},
+		}
+	},
 	"br": func(br *etree.Element) contenttree.Node {
 		return &contenttree.Break{
 			Type: contenttree.BreakType,
@@ -499,12 +511,6 @@ var defaultTransformers = map[string]transformer{
 		return newLiftChildrenNode()
 	},
 	"b": func(_ *etree.Element) contenttree.Node {
-		return newLiftChildrenNode()
-	},
-	"sup": func(_ *etree.Element) contenttree.Node {
-		return newLiftChildrenNode()
-	},
-	"sub": func(_ *etree.Element) contenttree.Node {
 		return newLiftChildrenNode()
 	},
 	"u": func(_ *etree.Element) contenttree.Node {

--- a/libraries/to-external-bodyxml/go/transform.go
+++ b/libraries/to-external-bodyxml/go/transform.go
@@ -140,6 +140,12 @@ func transformNode(n contenttree.Node) (string, error) {
 	case *contenttree.Strikethrough:
 		return fmt.Sprintf("<s>%s</s>", innerXML), nil
 
+	case *contenttree.Subscript:
+		return fmt.Sprintf("<sub>%s</sub>", innerXML), nil
+
+	case *contenttree.Superscript:
+		return fmt.Sprintf("<sup>%s</sup>", innerXML), nil
+
 	case *contenttree.Link:
 		href := html.EscapeString(node.URL)
 		if node.Title != "" {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@financial-times/content-tree",
 	"description": "content tree format",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"publishConfig": {
 		"access": "public"
   },

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -68,6 +68,12 @@
                                 "$ref": "#/definitions/ContentTree.transit.Strikethrough"
                             },
                             {
+                                "$ref": "#/definitions/ContentTree.transit.Subscript"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.Superscript"
+                            },
+                            {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
                             },
                             {
@@ -840,6 +846,12 @@
                                 "$ref": "#/definitions/ContentTree.transit.Strikethrough"
                             },
                             {
+                                "$ref": "#/definitions/ContentTree.transit.Subscript"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.Superscript"
+                            },
+                            {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
                             },
                             {
@@ -898,6 +910,12 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.Strikethrough"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.Subscript"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.Superscript"
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.Link"
@@ -1169,6 +1187,48 @@
                 "data": {},
                 "type": {
                     "const": "strong",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Subscript": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "subscript",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Superscript": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "superscript",
                     "type": "string"
                 }
             },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -80,6 +80,12 @@
                                 "$ref": "#/definitions/ContentTree.full.Strikethrough"
                             },
                             {
+                                "$ref": "#/definitions/ContentTree.full.Subscript"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.full.Superscript"
+                            },
+                            {
                                 "$ref": "#/definitions/ContentTree.full.Link"
                             },
                             {
@@ -1324,6 +1330,12 @@
                                 "$ref": "#/definitions/ContentTree.full.Strikethrough"
                             },
                             {
+                                "$ref": "#/definitions/ContentTree.full.Subscript"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.full.Superscript"
+                            },
+                            {
                                 "$ref": "#/definitions/ContentTree.full.Link"
                             },
                             {
@@ -1382,6 +1394,12 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.full.Strikethrough"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.full.Subscript"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.full.Superscript"
                 },
                 {
                     "$ref": "#/definitions/ContentTree.full.Link"
@@ -1989,6 +2007,48 @@
                 "data": {},
                 "type": {
                     "const": "strong",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.Subscript": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "subscript",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.full.Superscript": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.full.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "superscript",
                     "type": "string"
                 }
             },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -68,6 +68,12 @@
                                 "$ref": "#/definitions/ContentTree.transit.Strikethrough"
                             },
                             {
+                                "$ref": "#/definitions/ContentTree.transit.Subscript"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.Superscript"
+                            },
+                            {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
                             },
                             {
@@ -865,6 +871,12 @@
                                 "$ref": "#/definitions/ContentTree.transit.Strikethrough"
                             },
                             {
+                                "$ref": "#/definitions/ContentTree.transit.Subscript"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentTree.transit.Superscript"
+                            },
+                            {
                                 "$ref": "#/definitions/ContentTree.transit.Link"
                             },
                             {
@@ -923,6 +935,12 @@
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.Strikethrough"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.Subscript"
+                },
+                {
+                    "$ref": "#/definitions/ContentTree.transit.Superscript"
                 },
                 {
                     "$ref": "#/definitions/ContentTree.transit.Link"
@@ -1194,6 +1212,48 @@
                 "data": {},
                 "type": {
                     "const": "strong",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Subscript": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "subscript",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "children",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ContentTree.transit.Superscript": {
+            "additionalProperties": false,
+            "properties": {
+                "children": {
+                    "items": {
+                        "$ref": "#/definitions/ContentTree.transit.Phrasing"
+                    },
+                    "type": "array"
+                },
+                "data": {},
+                "type": {
+                    "const": "superscript",
                     "type": "string"
                 }
             },

--- a/tests/body-tree-to-external-bodyxml/input/simple-body-inline-formatting.json
+++ b/tests/body-tree-to-external-bodyxml/input/simple-body-inline-formatting.json
@@ -1,0 +1,76 @@
+{
+  "type": "body",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Start "
+        },
+        {
+          "type": "superscript",
+          "children": [
+            {
+              "type": "text",
+              "value": "sup"
+            }
+          ]
+        },
+        {
+          "type": "subscript",
+          "children": [
+            {
+              "type": "text",
+              "value": "sub"
+            }
+          ]
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "strong"
+            }
+          ]
+        },
+        {
+          "type": "strikethrough",
+          "children": [
+            {
+              "type": "text",
+              "value": "strikethrough"
+            }
+          ]
+        },
+
+        {
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "wrapped link"
+            }
+          ],
+          "title": "wrapped-link",
+          "url": "https://www.ft.com/content/123"
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "emphasis",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "wrapped emphasis"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/body-tree-to-external-bodyxml/output/simple-body-inline-formatting.xml
+++ b/tests/body-tree-to-external-bodyxml/output/simple-body-inline-formatting.xml
@@ -1,0 +1,1 @@
+<body><p>Start <sup>sup</sup><sub>sub</sub><strong>strong</strong><s>strikethrough</s><a href="https://www.ft.com/content/123" title="wrapped-link">wrapped link</a><strong><em>wrapped emphasis</em></strong></p></body>

--- a/tests/bodyxml-to-content-tree/output/simple-body-inline-formatting.json
+++ b/tests/bodyxml-to-content-tree/output/simple-body-inline-formatting.json
@@ -15,12 +15,22 @@
             "value": "bold"
           },
           {
-            "type": "text",
-            "value": "sup"
+            "type": "superscript",
+            "children": [
+              {
+                "type": "text",
+                "value": "sup"
+              }
+            ]
           },
           {
-            "type": "text",
-            "value": "sub"
+            "type": "subscript",
+            "children": [
+              {
+                "type": "text",
+                "value": "sub"
+              }
+            ]
           },
           {
             "type": "text",


### PR DESCRIPTION
Replaces #56 (which is far out of date)

This PR:
- adds super/subscript to the SPEC
- updates the go structs
- updates `to-external-bodyxml` and `from-bodyxml`
- Bumped package version to 0.9.0 (I will update if someone gets in before me)

I haven't changed `to-string` - at a glance the code doesn't look like it needs changing, and it seems the tests are failing anyway.
