### PR TITLE
fix: add id for component tracking

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1012,6 +1012,9 @@ interface InfoPair extends Parent {
 ```ts
 interface CarouselCard extends Node {
   type: "carousel-card"
+  /**
+   * @description unique identifier required for component tracking
+  */
   id: string
   /**
    * @description Heading (60 characters recommended)
@@ -1062,6 +1065,9 @@ interface CarouselHeading extends Node {
 */
 interface Carousel extends Parent {
    type: "carousel"
+   /**
+    * @description unique identifier required for component tracking
+   */
    id: string
    heading?: CarouselHeading
    children: CarouselChildren

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -441,6 +441,9 @@ export declare namespace ContentTree {
     }
     interface CarouselCard extends Node {
         type: "carousel-card";
+        /**
+         * @description unique identifier required for component tracking
+        */
         id: string;
         /**
          * @description Heading (60 characters recommended)
@@ -476,6 +479,9 @@ export declare namespace ContentTree {
     */
     interface Carousel extends Parent {
         type: "carousel";
+        /**
+         * @description unique identifier required for component tracking
+        */
         id: string;
         heading?: CarouselHeading;
         children: CarouselChildren;
@@ -923,6 +929,9 @@ export declare namespace ContentTree {
         }
         interface CarouselCard extends Node {
             type: "carousel-card";
+            /**
+             * @description unique identifier required for component tracking
+            */
             id: string;
             /**
              * @description Heading (60 characters recommended)
@@ -958,6 +967,9 @@ export declare namespace ContentTree {
         */
         interface Carousel extends Parent {
             type: "carousel";
+            /**
+             * @description unique identifier required for component tracking
+            */
             id: string;
             heading?: CarouselHeading;
             children: CarouselChildren;
@@ -1379,6 +1391,9 @@ export declare namespace ContentTree {
         }
         interface CarouselCard extends Node {
             type: "carousel-card";
+            /**
+             * @description unique identifier required for component tracking
+            */
             id: string;
             /**
              * @description Heading (60 characters recommended)
@@ -1414,6 +1429,9 @@ export declare namespace ContentTree {
         */
         interface Carousel extends Parent {
             type: "carousel";
+            /**
+             * @description unique identifier required for component tracking
+            */
             id: string;
             heading?: CarouselHeading;
             children: CarouselChildren;
@@ -1862,6 +1880,9 @@ export declare namespace ContentTree {
         }
         interface CarouselCard extends Node {
             type: "carousel-card";
+            /**
+             * @description unique identifier required for component tracking
+            */
             id: string;
             /**
              * @description Heading (60 characters recommended)
@@ -1897,6 +1918,9 @@ export declare namespace ContentTree {
         */
         interface Carousel extends Parent {
             type: "carousel";
+            /**
+             * @description unique identifier required for component tracking
+            */
             id: string;
             heading?: CarouselHeading;
             children: CarouselChildren;

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -267,6 +267,7 @@
                     "$ref": "#/definitions/ContentTree.transit.CarouselHeading"
                 },
                 "id": {
+                    "description": "unique identifier required for component tracking",
                     "type": "string"
                 },
                 "type": {
@@ -306,6 +307,7 @@
                 },
                 "data": {},
                 "id": {
+                    "description": "unique identifier required for component tracking",
                     "type": "string"
                 },
                 "title": {

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -303,6 +303,7 @@
                     "$ref": "#/definitions/ContentTree.full.CarouselHeading"
                 },
                 "id": {
+                    "description": "unique identifier required for component tracking",
                     "type": "string"
                 },
                 "type": {
@@ -341,6 +342,7 @@
                 },
                 "data": {},
                 "id": {
+                    "description": "unique identifier required for component tracking",
                     "type": "string"
                 },
                 "title": {

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -291,6 +291,7 @@
                     "$ref": "#/definitions/ContentTree.transit.CarouselHeading"
                 },
                 "id": {
+                    "description": "unique identifier required for component tracking",
                     "type": "string"
                 },
                 "type": {
@@ -329,6 +330,7 @@
                 },
                 "data": {},
                 "id": {
+                    "description": "unique identifier required for component tracking",
                     "type": "string"
                 },
                 "title": {


### PR DESCRIPTION
Add ID as it's mandatory for component tracking events (e.g. view, act)