### PR TITLE
ci-3692 inset vertical videos

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -681,7 +681,7 @@ type ClipAccessibility = {
 	transcript?: Body
 }
 
-type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">
+type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid" | "inset-left" | "inset-right">
 ```
 
 **ClipSet** represents a short piece of possibly-looping video content for an article.

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -256,7 +256,7 @@ export declare namespace ContentTree {
         captions?: ClipCaption[];
         transcript?: Body;
     };
-    type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
+    type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid" | "inset-left" | "inset-right">;
     interface ScrollyBlock extends Parent {
         type: "scrolly-block";
         theme: "sans" | "serif";
@@ -750,7 +750,7 @@ export declare namespace ContentTree {
             captions?: ClipCaption[];
             transcript?: Body;
         };
-        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
+        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid" | "inset-left" | "inset-right">;
         interface ScrollyBlock extends Parent {
             type: "scrolly-block";
             theme: "sans" | "serif";
@@ -1228,7 +1228,7 @@ export declare namespace ContentTree {
             captions?: ClipCaption[];
             transcript?: Body;
         };
-        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
+        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid" | "inset-left" | "inset-right">;
         interface ScrollyBlock extends Parent {
             type: "scrolly-block";
             theme: "sans" | "serif";
@@ -1713,7 +1713,7 @@ export declare namespace ContentTree {
             captions?: ClipCaption[];
             transcript?: Body;
         };
-        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid">;
+        type ClipSetLayoutWidth = Extract<LayoutWidth, "in-line" | "mid-grid" | "full-grid" | "inset-left" | "inset-right">;
         interface ScrollyBlock extends Parent {
             type: "scrolly-block";
             theme: "sans" | "serif";

--- a/libraries/from-bodyxml/go/helpers.go
+++ b/libraries/from-bodyxml/go/helpers.go
@@ -35,7 +35,7 @@ func toValidFlourishLayoutWidth(w string) layoutwidth {
 
 func toValidClipLayoutWidth(w string) layoutwidth {
 	switch w {
-	case "in-line", "full-grid", "mid-grid":
+	case "in-line", "full-grid", "mid-grid", "inset-left", "inset-right":
 		return layoutwidth(w)
 	default:
 		return "in-line"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@financial-times/content-tree",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@financial-times/content-tree",
-			"version": "0.12.0",
+			"version": "0.13.0",
 			"license": "MIT",
 			"workspaces": [
 				"libraries/*",

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -370,6 +370,8 @@
             "enum": [
                 "full-grid",
                 "in-line",
+                "inset-left",
+                "inset-right",
                 "mid-grid"
             ],
             "type": "string"

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -497,6 +497,8 @@
             "enum": [
                 "full-grid",
                 "in-line",
+                "inset-left",
+                "inset-right",
                 "mid-grid"
             ],
             "type": "string"

--- a/schemas/spark-transit-tree.schema.json
+++ b/schemas/spark-transit-tree.schema.json
@@ -462,6 +462,8 @@
             "enum": [
                 "full-grid",
                 "in-line",
+                "inset-left",
+                "inset-right",
                 "mid-grid"
             ],
             "type": "string"

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -395,6 +395,8 @@
             "enum": [
                 "full-grid",
                 "in-line",
+                "inset-left",
+                "inset-right",
                 "mid-grid"
             ],
             "type": "string"


### PR DESCRIPTION
So that vertical videos can be inset to the left or right, this PR adds "inset-left" | "inset-right" to `ClipSetLayoutWidth` 

ticket: https://financialtimes.atlassian.net/browse/CI-3692
