### PR TITLE
uppsf-7115 add data-fragment-identifier to video

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -590,6 +590,7 @@ interface BigNumber extends Node {
 interface Video extends Node {
 	type: "video"
 	id: string
+	fragmentIdentifier?: string
     external title: string
 }
 ```

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -202,6 +202,7 @@ export declare namespace ContentTree {
     interface Video extends Node {
         type: "video";
         id: string;
+        fragmentIdentifier?: string;
         title: string;
     }
     interface YoutubeVideo extends Node {
@@ -696,6 +697,7 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
+            fragmentIdentifier?: string;
             title: string;
         }
         interface YoutubeVideo extends Node {
@@ -1187,6 +1189,7 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
+            fragmentIdentifier?: string;
         }
         interface YoutubeVideo extends Node {
             type: "youtube-video";
@@ -1659,6 +1662,7 @@ export declare namespace ContentTree {
         interface Video extends Node {
             type: "video";
             id: string;
+            fragmentIdentifier?: string;
             title?: string;
         }
         interface YoutubeVideo extends Node {

--- a/content_tree.go
+++ b/content_tree.go
@@ -2912,8 +2912,9 @@ func (n *Tweet) GetChildren() []Node {
 func (n *Tweet) AppendChild(child Node) error { return ErrCannotHaveChildren }
 
 type Video struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
+	Type               string `json:"type"`
+	ID                 string `json:"id"`
+	FragmentIdentifier string `json:"fragmentIdentifier,omitempty"`
 }
 
 func (n *Video) GetType() string {

--- a/libraries/from-bodyxml/go/html_transformers.go
+++ b/libraries/from-bodyxml/go/html_transformers.go
@@ -326,8 +326,9 @@ var defaultTransformers = map[string]transformer{
 	},
 	contentType.Video: func(content *etree.Element) contenttree.Node {
 		return &contenttree.Video{
-			Type: contenttree.VideoType,
-			ID:   attr(content, "id"),
+			Type:               contenttree.VideoType,
+			ID:                 attr(content, "id"),
+			FragmentIdentifier: attr(content, "data-fragment-identifier"),
 		}
 	},
 	contentType.Content: func(content *etree.Element) contenttree.Node {

--- a/libraries/to-external-bodyxml/go/transform.go
+++ b/libraries/to-external-bodyxml/go/transform.go
@@ -306,6 +306,9 @@ func transformNode(n contenttree.Node) (string, error) {
 		return fmt.Sprintf("<table>%s</table>", strings.Join(childrenXML, "")), nil
 
 	case *contenttree.Video:
+		if node.FragmentIdentifier != "" {
+			return fmt.Sprintf("<ft-content type=\"http://www.ft.com/ontology/content/Video\" url=\"http://api.ft.com/content/%s\" data-embedded=\"true\" data-fragment-identifier=\"%s\"></ft-content>", node.ID, html.EscapeString(node.FragmentIdentifier)), nil
+		}
 		return fmt.Sprintf("<ft-content type=\"http://www.ft.com/ontology/content/Video\" url=\"http://api.ft.com/content/%s\" data-embedded=\"true\"></ft-content>", node.ID), nil
 
 	case *contenttree.YoutubeVideo:

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -1725,6 +1725,9 @@
             "additionalProperties": false,
             "properties": {
                 "data": {},
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -2549,6 +2549,9 @@
             "additionalProperties": false,
             "properties": {
                 "data": {},
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/schemas/spark-transit-tree.schema.json
+++ b/schemas/spark-transit-tree.schema.json
@@ -2074,6 +2074,9 @@
             "additionalProperties": false,
             "properties": {
                 "data": {},
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -2085,6 +2088,7 @@
             "propertyOrder": [
                 "type",
                 "id",
+                "fragmentIdentifier",
                 "data"
             ],
             "required": [

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -1750,6 +1750,9 @@
             "additionalProperties": false,
             "properties": {
                 "data": {},
+                "fragmentIdentifier": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/tests/body-tree-to-external-bodyxml/input/video.json
+++ b/tests/body-tree-to-external-bodyxml/input/video.json
@@ -1,0 +1,11 @@
+{
+  "type": "body",
+  "children": [
+    {
+      "type": "video",
+      "id": "video-123",
+      "fragmentIdentifier": "video-fragment"
+    }
+  ],
+  "version": 1
+}

--- a/tests/body-tree-to-external-bodyxml/output/video.xml
+++ b/tests/body-tree-to-external-bodyxml/output/video.xml
@@ -1,0 +1,1 @@
+<body><ft-content type="http://www.ft.com/ontology/content/Video" url="http://api.ft.com/content/video-123" data-embedded="true" data-fragment-identifier="video-fragment"></ft-content></body>

--- a/tests/bodyxml-to-content-tree/input/simple-body-video.xml
+++ b/tests/bodyxml-to-content-tree/input/simple-body-video.xml
@@ -1,0 +1,1 @@
+<body><content type="http://www.ft.com/ontology/content/Video" id="video-123"></content></body>

--- a/tests/bodyxml-to-content-tree/output/simple-body-video.json
+++ b/tests/bodyxml-to-content-tree/output/simple-body-video.json
@@ -1,0 +1,13 @@
+{
+  "type": "root",
+  "body": {
+    "type": "body",
+    "children": [
+      {
+        "type": "video",
+        "id": "video-123"
+      }
+    ],
+    "version": 1
+  }
+}


### PR DESCRIPTION
Add support for the `data-fragment-identifier attribute` on FT Video elements.
[Jira ticket](https://financialtimes.atlassian.net/browse/UPPSF-7115)