### PR TITLE
fix: set min 3 cards for carousel

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1046,7 +1046,7 @@ interface CarouselCard extends Node {
 /**
  * @description Carousel item
  * @maxItems 10
- * @minItems 4
+ * @minItems 3
  * @sparkRepeater true
  */
 type CarouselChildren = CarouselCard[]

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -470,7 +470,7 @@ export declare namespace ContentTree {
     /**
      * @description Carousel item
      * @maxItems 10
-     * @minItems 4
+     * @minItems 3
      * @sparkRepeater true
      */
     type CarouselChildren = CarouselCard[];
@@ -965,7 +965,7 @@ export declare namespace ContentTree {
         /**
          * @description Carousel item
          * @maxItems 10
-         * @minItems 4
+         * @minItems 3
          * @sparkRepeater true
          */
         type CarouselChildren = CarouselCard[];
@@ -1434,7 +1434,7 @@ export declare namespace ContentTree {
         /**
          * @description Carousel item
          * @maxItems 10
-         * @minItems 4
+         * @minItems 3
          * @sparkRepeater true
          */
         type CarouselChildren = CarouselCard[];
@@ -1930,7 +1930,7 @@ export declare namespace ContentTree {
         /**
          * @description Carousel item
          * @maxItems 10
-         * @minItems 4
+         * @minItems 3
          * @sparkRepeater true
          */
         type CarouselChildren = CarouselCard[];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@financial-times/content-tree",
 	"description": "content tree format",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"publishConfig": {
 		"access": "public"
   },

--- a/schemas/body-tree.schema.json
+++ b/schemas/body-tree.schema.json
@@ -261,7 +261,7 @@
                         "$ref": "#/definitions/ContentTree.transit.CarouselCard"
                     },
                     "maxItems": 10,
-                    "minItems": 4,
+                    "minItems": 3,
                     "type": "array"
                 },
                 "data": {},

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -298,7 +298,7 @@
                         "$ref": "#/definitions/ContentTree.full.CarouselCard"
                     },
                     "maxItems": 10,
-                    "minItems": 4,
+                    "minItems": 3,
                     "type": "array"
                 },
                 "data": {},

--- a/schemas/spark-transit-tree.schema.json
+++ b/schemas/spark-transit-tree.schema.json
@@ -318,7 +318,7 @@
                         "$ref": "#/definitions/ContentTree.transit.CarouselCard"
                     },
                     "maxItems": 10,
-                    "minItems": 4,
+                    "minItems": 3,
                     "sparkRepeater": true,
                     "type": "array"
                 },

--- a/schemas/transit-tree.schema.json
+++ b/schemas/transit-tree.schema.json
@@ -286,7 +286,7 @@
                         "$ref": "#/definitions/ContentTree.transit.CarouselCard"
                     },
                     "maxItems": 10,
-                    "minItems": 4,
+                    "minItems": 3,
                     "type": "array"
                 },
                 "data": {},


### PR DESCRIPTION
This PR:

- changes the minimum cards required for a carousel from 4 to 3 at the request of editorial
- bumps the version number