### PR TITLE
ci-3671: add new asset formats

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -17,6 +17,8 @@ type AssetFormat =
 	| "standard"
 	| "wide"
 	| "standard-inline"
+	| "portrait"
+	| "landscape"
 
 ```
 

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -1,5 +1,5 @@
 export declare namespace ContentTree {
-    type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline";
+    type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline" | "portrait" | "landscape";
     type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
     type AVSource = {
         binaryUrl: string;
@@ -494,7 +494,7 @@ export declare namespace ContentTree {
         children: CarouselChildren;
     }
     namespace full {
-        type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline";
+        type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline" | "portrait" | "landscape";
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type AVSource = {
             binaryUrl: string;
@@ -990,7 +990,7 @@ export declare namespace ContentTree {
         }
     }
     namespace transit {
-        type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline";
+        type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline" | "portrait" | "landscape";
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type AVSource = {
             binaryUrl: string;
@@ -1459,7 +1459,7 @@ export declare namespace ContentTree {
         }
     }
     namespace loose {
-        type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline";
+        type AssetFormat = "desktop" | "mobile" | "square" | "square-ftedit" | "standard" | "wide" | "standard-inline" | "portrait" | "landscape";
         type LayoutWidth = "auto" | "in-line" | "inset-left" | "inset-right" | "full-bleed" | "full-grid" | "mid-grid" | "full-width";
         type AVSource = {
             binaryUrl: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@financial-times/content-tree",
-	"version": "0.13.0",
+	"version": "0.17.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@financial-times/content-tree",
-			"version": "0.13.0",
+			"version": "0.17.0",
 			"license": "MIT",
 			"workspaces": [
 				"libraries/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@financial-times/content-tree",
 	"description": "content tree format",
-	"version": "0.17.0",
+	"version": "0.18.0",
 	"publishConfig": {
 		"access": "public"
   },

--- a/schemas/content-tree.schema.json
+++ b/schemas/content-tree.schema.json
@@ -24,7 +24,9 @@
         "ContentTree.full.AssetFormat": {
             "enum": [
                 "desktop",
+                "landscape",
                 "mobile",
+                "portrait",
                 "square",
                 "square-ftedit",
                 "standard",


### PR DESCRIPTION
To resolve issue https://github.com/Financial-Times/content-tree/issues/85

The portrait and landscape image types are currently missing from content tree. The logic already exists to consume these types [in cp-content-pipeline](https://github.com/Financial-Times/cp-content-pipeline/blob/6e51a21f67627dff505466a74ada521419a15b1a/packages/schema/src/resolvers/content-tree/Workarounds.ts#L180-L181) which _i think_ should allow us to remove the workaround.

Additional Context:
This was documented in the CP content pipelines [workaround review doc](https://docs.google.com/spreadsheets/d/1E0M1OBLNmC7O1QpMcvROhwUWnMcyuWAxD_sFClUTzUc/edit?gid=0#gid=0)