### PR TITLE
UPPSF-7152 Bump version to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@financial-times/content-tree",
 	"description": "content tree format",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"publishConfig": {
 		"access": "public"
   },


### PR DESCRIPTION
## What

Bump `@financial-times/content-tree` from `0.18.0` to `0.19.0`.

## Why

BodyXML fallback support added in the main UPPSF-7152 content-tree ticket as a `0.19.0` release.