### PR TITLE
add a new keyword for Spark fields

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1027,16 +1027,19 @@ interface CarouselCard extends Node {
   /**
    * @description Heading (60 characters recommended)
    * @sparkMapNodeType textInput
+   * @sparkFieldLabel Slide heading
   */
   title: string
   /**
    * @description Body text (200 characters recommended)
-   * @sparkMapNodeType textInput
+   * @sparkFieldLabel Slide body text
+   * @sparkMapNodeType textArea
   */
   copy: string
   /**
    * @description Details (optional, 60 characters recommended)
-   * @sparkMapNodeType textInput
+   * @sparkMapNodeType textArea
+   * @sparkFieldLabel Details
   */
   additionalInfo?: string
 }
@@ -1067,11 +1070,13 @@ interface Carousel extends Parent {
    */
    id: string
    /**
-   @sparkMapNodeType textInput
+   * @sparkMapNodeType textInput
+   * @sparkFieldLabel Heading
    */
    title?: string
    /**
-   @sparkMapNodeType textInput
+   * @sparkMapNodeType textArea
+   * @sparkFieldLabel Subheading
    */
    standfirst?: string
    children: CarouselChildren

--- a/build.bash
+++ b/build.bash
@@ -4,6 +4,6 @@ tsc -d content-tree.ts
 typescript-json-schema --noExtraProps --required content-tree.ts ContentTree.full.Root > schemas/content-tree.schema.json
 typescript-json-schema --noExtraProps --required content-tree.ts ContentTree.transit.Root > schemas/transit-tree.schema.json
 typescript-json-schema --noExtraProps --required content-tree.ts ContentTree.transit.Body > schemas/body-tree.schema.json
-typescript-json-schema --validationKeywords sparkMapNodeType sparkGenerateStoryblock sparkRepeater minItem maxItem --propOrder --noExtraProps --required content-tree.ts ContentTree.transit.Root > schemas/spark-transit-tree.schema.json
+typescript-json-schema --validationKeywords sparkFieldLabel sparkMapNodeType sparkGenerateStoryblock sparkRepeater minItem maxItem --propOrder --noExtraProps --required content-tree.ts ContentTree.transit.Root > schemas/spark-transit-tree.schema.json
 rm content-tree.ts
 rm content-tree.js

--- a/content-tree.d.ts
+++ b/content-tree.d.ts
@@ -454,16 +454,19 @@ export declare namespace ContentTree {
         /**
          * @description Heading (60 characters recommended)
          * @sparkMapNodeType textInput
+         * @sparkFieldLabel Slide heading
         */
         title: string;
         /**
          * @description Body text (200 characters recommended)
-         * @sparkMapNodeType textInput
+         * @sparkFieldLabel Slide body text
+         * @sparkMapNodeType textArea
         */
         copy: string;
         /**
          * @description Details (optional, 60 characters recommended)
-         * @sparkMapNodeType textInput
+         * @sparkMapNodeType textArea
+         * @sparkFieldLabel Details
         */
         additionalInfo?: string;
     }
@@ -484,11 +487,13 @@ export declare namespace ContentTree {
         */
         id: string;
         /**
-        @sparkMapNodeType textInput
+        * @sparkMapNodeType textInput
+        * @sparkFieldLabel Heading
         */
         title?: string;
         /**
-        @sparkMapNodeType textInput
+        * @sparkMapNodeType textArea
+        * @sparkFieldLabel Subheading
         */
         standfirst?: string;
         children: CarouselChildren;
@@ -949,16 +954,19 @@ export declare namespace ContentTree {
             /**
              * @description Heading (60 characters recommended)
              * @sparkMapNodeType textInput
+             * @sparkFieldLabel Slide heading
             */
             title: string;
             /**
              * @description Body text (200 characters recommended)
-             * @sparkMapNodeType textInput
+             * @sparkFieldLabel Slide body text
+             * @sparkMapNodeType textArea
             */
             copy: string;
             /**
              * @description Details (optional, 60 characters recommended)
-             * @sparkMapNodeType textInput
+             * @sparkMapNodeType textArea
+             * @sparkFieldLabel Details
             */
             additionalInfo?: string;
         }
@@ -979,11 +987,13 @@ export declare namespace ContentTree {
             */
             id: string;
             /**
-            @sparkMapNodeType textInput
+            * @sparkMapNodeType textInput
+            * @sparkFieldLabel Heading
             */
             title?: string;
             /**
-            @sparkMapNodeType textInput
+            * @sparkMapNodeType textArea
+            * @sparkFieldLabel Subheading
             */
             standfirst?: string;
             children: CarouselChildren;
@@ -1418,16 +1428,19 @@ export declare namespace ContentTree {
             /**
              * @description Heading (60 characters recommended)
              * @sparkMapNodeType textInput
+             * @sparkFieldLabel Slide heading
             */
             title: string;
             /**
              * @description Body text (200 characters recommended)
-             * @sparkMapNodeType textInput
+             * @sparkFieldLabel Slide body text
+             * @sparkMapNodeType textArea
             */
             copy: string;
             /**
              * @description Details (optional, 60 characters recommended)
-             * @sparkMapNodeType textInput
+             * @sparkMapNodeType textArea
+             * @sparkFieldLabel Details
             */
             additionalInfo?: string;
         }
@@ -1448,11 +1461,13 @@ export declare namespace ContentTree {
             */
             id: string;
             /**
-            @sparkMapNodeType textInput
+            * @sparkMapNodeType textInput
+            * @sparkFieldLabel Heading
             */
             title?: string;
             /**
-            @sparkMapNodeType textInput
+            * @sparkMapNodeType textArea
+            * @sparkFieldLabel Subheading
             */
             standfirst?: string;
             children: CarouselChildren;
@@ -1914,16 +1929,19 @@ export declare namespace ContentTree {
             /**
              * @description Heading (60 characters recommended)
              * @sparkMapNodeType textInput
+             * @sparkFieldLabel Slide heading
             */
             title: string;
             /**
              * @description Body text (200 characters recommended)
-             * @sparkMapNodeType textInput
+             * @sparkFieldLabel Slide body text
+             * @sparkMapNodeType textArea
             */
             copy: string;
             /**
              * @description Details (optional, 60 characters recommended)
-             * @sparkMapNodeType textInput
+             * @sparkMapNodeType textArea
+             * @sparkFieldLabel Details
             */
             additionalInfo?: string;
         }
@@ -1944,11 +1962,13 @@ export declare namespace ContentTree {
             */
             id: string;
             /**
-            @sparkMapNodeType textInput
+            * @sparkMapNodeType textInput
+            * @sparkFieldLabel Heading
             */
             title?: string;
             /**
-            @sparkMapNodeType textInput
+            * @sparkMapNodeType textArea
+            * @sparkFieldLabel Subheading
             */
             standfirst?: string;
             children: CarouselChildren;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@financial-times/content-tree",
 	"description": "content tree format",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"publishConfig": {
 		"access": "public"
   },

--- a/schemas/spark-transit-tree.schema.json
+++ b/schemas/spark-transit-tree.schema.json
@@ -328,10 +328,12 @@
                     "type": "string"
                 },
                 "standfirst": {
-                    "sparkMapNodeType": "textInput",
+                    "sparkFieldLabel": "Subheading",
+                    "sparkMapNodeType": "textArea",
                     "type": "string"
                 },
                 "title": {
+                    "sparkFieldLabel": "Heading",
                     "sparkMapNodeType": "textInput",
                     "type": "string"
                 },
@@ -361,7 +363,8 @@
             "properties": {
                 "additionalInfo": {
                     "description": "Details (optional, 60 characters recommended)",
-                    "sparkMapNodeType": "textInput",
+                    "sparkFieldLabel": "Details",
+                    "sparkMapNodeType": "textArea",
                     "type": "string"
                 },
                 "children": {
@@ -378,7 +381,8 @@
                 },
                 "copy": {
                     "description": "Body text (200 characters recommended)",
-                    "sparkMapNodeType": "textInput",
+                    "sparkFieldLabel": "Slide body text",
+                    "sparkMapNodeType": "textArea",
                     "type": "string"
                 },
                 "data": {},
@@ -388,6 +392,7 @@
                 },
                 "title": {
                     "description": "Heading (60 characters recommended)",
+                    "sparkFieldLabel": "Slide heading",
                     "sparkMapNodeType": "textInput",
                     "type": "string"
                 },


### PR DESCRIPTION
Editors do not like camel case names and the UX team have different names for the fields labels.
This PR is adding a new keyword for Spark so we can name the fields without effecting the other teams.