### PR TITLE
Preserve whitespace-only BodyXML text nodes when converting to content tree

### DIFF
--- a/libraries/from-bodyxml/go/transform.go
+++ b/libraries/from-bodyxml/go/transform.go
@@ -107,9 +107,6 @@ func convertToContentTree(elem etree.Token, m contenttree.Node) error {
 		}
 	case *etree.CharData:
 		data := t.Data
-		if strings.TrimSpace(data) == "" {
-			return nil
-		}
 		tx := &contenttree.Text{
 			Value: data,
 			Type:  contenttree.TextType,

--- a/tests/bodyxml-to-content-tree/output/simple-body-inline-formatting.json
+++ b/tests/bodyxml-to-content-tree/output/simple-body-inline-formatting.json
@@ -49,6 +49,10 @@
             "value": "small"
           },
           {
+            "type": "text",
+            "value": " "
+          },
+          {
             "type": "link",
             "children": [
               {
@@ -58,6 +62,10 @@
             ],
             "title": "wrapped-link",
             "url": "https://www.ft.com/content/123"
+          },
+          {
+            "type": "text",
+            "value": " "
           },
           {
             "type": "emphasis",

--- a/tests/bodyxml-to-content-tree/output/simple-body-scrolly.json
+++ b/tests/bodyxml-to-content-tree/output/simple-body-scrolly.json
@@ -4,6 +4,10 @@
     "type": "body",
     "children": [
       {
+        "type": "text",
+        "value": "\n  "
+      },
+      {
         "type": "scrolly-block",
         "children": [
           {
@@ -126,6 +130,10 @@
           }
         ],
         "theme": "serif"
+      },
+      {
+        "type": "text",
+        "value": "\n"
       }
     ],
     "version": 1

--- a/tests/bodyxml-to-content-tree/output/simple-body-whitespace-only-text-nodes.json
+++ b/tests/bodyxml-to-content-tree/output/simple-body-whitespace-only-text-nodes.json
@@ -4,6 +4,10 @@
     "type": "body",
     "children": [
       {
+        "type": "text",
+        "value": "\n"
+      },
+      {
         "type": "paragraph",
         "children": [
           {
@@ -16,6 +20,10 @@
             ]
           },
           {
+            "type": "text",
+            "value": "\n"
+          },
+          {
             "type": "strong",
             "children": [
               {
@@ -25,6 +33,10 @@
             ]
           }
         ]
+      },
+      {
+        "type": "text",
+        "value": "\n"
       }
     ],
     "version": 1


### PR DESCRIPTION
This PR removes the code in the bodyxml to tree transformer that stripped white spaces from the text nodes and skipped them if found empty. 

Before the fix, the xml ```<strong>Monday:</strong> <a href=\"https://www.ft.com/content/6bc324bd-9287-4277-aa31-c4a3ab3e0b95\">Business</a> by Andrew Hill<br/>``` produced

<img width="458" height="73" alt="Screenshot 2026-08-04 at 14 05 13" src="https://github.com/user-attachments/assets/06ec84f7-11b8-48d8-95ac-7e238f3920e0" />


[Now](https://article.in.ft.com/content/a7d99171-ddab-47b8-9891-53dd76e3e83d):

<img width="448" height="71" alt="Screenshot 2026-08-04 at 14 04 20" src="https://github.com/user-attachments/assets/eec3a0d4-0be6-426d-b1cd-f8e77f02c11b" />



JIRA --> https://financialtimes.atlassian.net/browse/UPPSF-7221

