### PR TITLE
Bump version from 0.20.0 to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@financial-times/content-tree",
 	"description": "content tree format",
-	"version": "0.20.0",
+	"version": "0.21.0",
 	"publishConfig": {
 		"access": "public"
   },


### PR DESCRIPTION
Bump `@financial-times/content-tree` from `0.20.0` to `0.21.0`.
